### PR TITLE
Removing Force switch as Set-AzureRmResourceGroup doesn't support 

### DIFF
--- a/src/AzSK/Framework/Helpers/Helpers.ps1
+++ b/src/AzSK/Framework/Helpers/Helpers.ps1
@@ -956,7 +956,7 @@ class Helpers {
 			}
 			try
 			{
-				Set-AzureRmResourceGroup -Name $RGName -Tag $tags -Force -ErrorAction Stop
+				Set-AzureRmResourceGroup -Name $RGName -Tag $tags -ErrorAction Stop
 			}
 			catch
 			{


### PR DESCRIPTION
## Description
</br>
I had added Force switch for Set-AzureRmResourceGroup as it was present for Set-AzureRmResource. But Set-AzureRmResourceGroup doesn't support Force switch.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
