### PR TITLE
1809/asc patch fix

### DIFF
--- a/src/AzSK/Framework/Core/SubscriptionSecurity/ARMPolicies.ps1
+++ b/src/AzSK/Framework/Core/SubscriptionSecurity/ARMPolicies.ps1
@@ -7,6 +7,7 @@ class ARMPolicy: CommandBase
 	hidden [ARMPolicyModel] $ARMPolicyObj = $null;
 	hidden [PolicyInitiative] $SubPolicyInitiative = $null;
 	hidden [bool] $UpdateInitiative = $false;
+	static [string] $PolicyProviderNamespace = "Microsoft.PolicyInsights";
 	
 	hidden [PSObject[]] $ApplicableARMPolicies = $null;
 	#hidden [PSObject[]] $PolicyAssignments = $null;
@@ -60,7 +61,7 @@ class ARMPolicy: CommandBase
 
 	[MessageData[]] SetARMPolicies()
     {
-		
+		[Helpers]::RegisterResourceProviderIfNotRegistered([ARMPolicy]::PolicyProviderNamespace);
 		[MessageData[]] $messages = @();
 		$this.RemoveDeprecatedPolicies();
 		if(($this.ARMPolicyObj.Policies | Measure-Object).Count -ne 0)

--- a/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
+++ b/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
@@ -141,8 +141,9 @@ class SecurityCenter: AzSKRoot
             {
 				#return failure status if api throws exception.
 				return "AutoProvisioning: [ASC is either not configured or not able to fetch ASC provisioning status due to access issue]"
-            }
-			if(-not ([Helpers]::CheckMember($response,"properties.autoProvision") -and $response.properties.autoProvision -eq "On" ))
+			}
+			$autoProvisionObject = $this.PolicyObject.autoProvisioning
+			if(-not (-not ([Helpers]::CheckMember($autoProvisionObject,"properties.autoProvision",$false)) -or ([Helpers]::CheckMember($response,"properties.autoProvision") -and ($response.properties.autoProvision -eq $autoProvisionObject.properties.autoProvision))))
 			{
 				return "AutoProvisioning: [Failed]"
 			}
@@ -178,18 +179,17 @@ class SecurityCenter: AzSKRoot
 				#return failure status if api throws exception.
                 return "SecurityContactsConfig: [Security contact details is either not configured or not able to fetch configuration due to access issue]"
 			}
-			
+			$secContactObject = $this.PolicyObject.securityContacts
 			if([Helpers]::CheckMember($response,"properties.email") -and -not [string]::IsNullOrWhiteSpace($response.properties.email) `
 				-and [Helpers]::CheckMember($response,"properties.phone") -and -not [string]::IsNullOrWhiteSpace($response.properties.phone))				
 			{
 				$this.ContactEmail = $response.properties.email;
 				$this.ContactPhoneNumber = $response.properties.phone;
-				if(-not ([Helpers]::CheckMember($response,"properties.email") -and -not [string]::IsNullOrWhiteSpace($response.properties.email) `
-				-and [Helpers]::CheckMember($response,"properties.phone") -and -not [string]::IsNullOrWhiteSpace($response.properties.phone) `
-				-and [Helpers]::CheckMember($response,"properties.alertNotifications") -and $response.properties.alertNotifications -eq "On" `
-				-and [Helpers]::CheckMember($response,"properties.alertsToAdmins") -and $response.properties.alertsToAdmins -eq "On"))			
-				{
-                     
+				if(-not ((-not ([Helpers]::CheckMember($secContactObject,"properties.email",$false)) -or ([Helpers]::CheckMember($response,"properties.email") -and -not [string]::IsNullOrWhiteSpace($response.properties.email)))`
+					 -and (-not ([Helpers]::CheckMember($secContactObject,"properties.phone",$false)) -or ([Helpers]::CheckMember($response,"properties.phone") -and -not [string]::IsNullOrWhiteSpace($response.properties.phone)))`
+					 -and (-not ([Helpers]::CheckMember($secContactObject,"properties.alertNotifications",$false)) -or ([Helpers]::CheckMember($response,"properties.alertNotifications") -and ($response.properties.alertNotifications -eq $secContactObject.properties.alertNotifications)))`
+					 -and (-not ([Helpers]::CheckMember($secContactObject,"properties.alertsToAdmins",$false)) -or ([Helpers]::CheckMember($response,"properties.alertsToAdmins") -and ($response.properties.alertsToAdmins -eq $secContactObject.properties.alertsToAdmins)))))
+				{                   
 					return "SecurityContactsConfig: [Failed. One of the configuration(Email,Phone,SendEmailAlertNotification,SendEmailAlertsToAdmin) is missing]"
 				}				
 			}

--- a/src/AzSK/Framework/Helpers/SecurityCenterHelper.ps1
+++ b/src/AzSK/Framework/Helpers/SecurityCenterHelper.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 class SecurityCenterHelper
 {
 	static [string] $ProviderNamespace = "Microsoft.Security";
+	static [string] $PolicyProviderNamespace = "Microsoft.PolicyInsights";
 	static [string] $PoliciesApi = "policies/default";
 	static [string] $AlertsApi = "alerts";
 	static [string] $AutoProvisioningSettingsApi = "autoProvisioningSettings";
@@ -110,6 +111,7 @@ class SecurityCenterHelper
 
 	static [void] RegisterResourceProvider()
 	{
+		[Helpers]::RegisterResourceProviderIfNotRegistered([SecurityCenterHelper]::PolicyProviderNamespace);
 		[Helpers]::RegisterResourceProviderIfNotRegistered([SecurityCenterHelper]::ProviderNamespace);
 	}
 


### PR DESCRIPTION
## Description
</br>
 ASC API URI is generated using SecurityCenter.json
Also, there was an spelling error in the "id" parameter of policySettings. Corrected it.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
