### PR TITLE
[Baseline Control validation] Recommendation changed : -Force parameter doesn't work.

### DIFF
--- a/src/AzSK/Framework/Configurations/SVT/Services/Automation.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/Automation.json
@@ -66,7 +66,7 @@
       "Automated": "Yes",
       "MethodName": "CheckVariables",
       "Rationale": "Encrypted variables are stored securely by the Azure platform. Moreover, their values cannot be retrieved from the Get-AzureRmAutomationVariable cmdlet that ships as part of the Azure PowerShell module.",
-      "Recommendation": "Encrypt variable if it stores sensitive data. Create a new encrypted copy of each unencrypted variable in the automation account and delete the unencrypted variables later. Run command 'New-AzureRmAutomationVariable -AutomationAccountName '{AutomationAccountName}' -Name '{VariableName}' -Encrypted `$true -Value '{Value} -ResourceGroupName '{ResourceGroupName}' and 'Remove-AzureRmAutomationVariable -AutomationAccountName '{AutomationAccountName}' -Name '{VariableName}' -Force -ResourceGroupName '{ResourceGroupName}'",
+      "Recommendation": "Encrypt variable if it stores sensitive data. Create a new encrypted copy of each unencrypted variable in the automation account and delete the unencrypted variables later. Run command 'New-AzureRmAutomationVariable -AutomationAccountName '{AutomationAccountName}' -Name '{VariableName}' -Encrypted `$true -Value '{Value} -ResourceGroupName '{ResourceGroupName}' and 'Remove-AzureRmAutomationVariable -AutomationAccountName '{AutomationAccountName}' -Name '{VariableName}' -ResourceGroupName '{ResourceGroupName}'",
       "Tags": [
         "SDL",
         "TCP",

--- a/src/AzSK/Framework/Core/SVT/AzSKCfg/AzSKCfg.ps1
+++ b/src/AzSK/Framework/Core/SVT/AzSKCfg/AzSKCfg.ps1
@@ -103,7 +103,7 @@ class AzSKCfg: SVTBase
 
 			if($HasGraphAPIAccess)
 			{	
-				#region: Check if service principal is configured and it has at least Security Reader access to subscription and contributor access to "AzSKRG", if either is missing display error message				
+				#region: Check if service principal is configured and it has at least Reader access to subscription and contributor access to "AzSKRG", if either is missing display error message				
 				$stepCount++
 				$isPassed = $false
 				$runAsConnection = $this.GetRunAsConnection()
@@ -285,7 +285,7 @@ class AzSKCfg: SVTBase
 		#Check subscription access
 		if(($spPermissions|measure-object).count -gt 0)
 		{
-			$haveSubscriptionAccess = ($spPermissions | Where-Object {$_.scope -eq "/subscriptions/$($currentContext.Subscription.Id)" -and $_.RoleDefinitionName -eq "Security Reader"}|Measure-Object).count -gt 0
+			$haveSubscriptionAccess = ($spPermissions | Where-Object {$_.scope -eq "/subscriptions/$($currentContext.Subscription.Id)" -and $_.RoleDefinitionName -eq "Reader"}|Measure-Object).count -gt 0
 			return $haveSubscriptionAccess	
 		}
 		else


### PR DESCRIPTION
## Description
</br>
Recommendation for the control "Azure_Automation_DP_Use_Encrypted_Variables" is modified. The -Force parameter has been removed from the Remove-AzureRmAutomationVariable command in the recommendation as it was throwing error. It works fine when the parameter is not used.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
