### PR TITLE
Take the IsEnabled control property into account in ARMControls.json by ARM template checker

### DIFF
--- a/src/AzSK.ARMChecker.Lib/ResourceEvaluator.cs
+++ b/src/AzSK.ARMChecker.Lib/ResourceEvaluator.cs
@@ -31,7 +31,9 @@ namespace AzSK.ARMChecker.Lib
                 return new List<ControlResult> { ControlResult.NotSupported(resource) };
             }
             var results = new List<ControlResult>();
-            foreach (var control in controlSet.Controls)
+            var controlsToEvaluate = controlSet.Controls.Where(c => c.IsEnabled == true);
+            //foreach (var control in controlSet.Controls)
+            foreach (var control in controlsToEvaluate)
             {
                 control.FeatureName = controlSet.FeatureName;
                 control.SupportedResources = controlSet.supportedResourceTypes.ToArray().ToSingleString(" , ");
@@ -47,7 +49,9 @@ namespace AzSK.ARMChecker.Lib
             var featureName = resources?.First().FeatureName;
             var controlSet = resourceControlSets?.FirstOrDefault(x => x.FeatureName.Equals(featureName, StringComparison.OrdinalIgnoreCase));
             var results = new List<ControlResult>();
-            foreach (var control in controlSet.Controls)
+            var controlsToEvaluate = controlSet.Controls.Where(c => c.IsEnabled == true);
+            //foreach (var control in controlSet.Controls)
+            foreach (var control in controlsToEvaluate)
             {
                 List<string> resourcePathList = new List<string>();
                 ControlResult controlResult = null;


### PR DESCRIPTION
## Description
</br>
This fix is to make sure the isEnabled attribute of ARM Controls defined in ARMControls.json are taken into account by the ARM checker library. Currently, whether a control's isEnabled attribute is set to false or true, it is always evaluated. The fix makes sure to only evaluate controls that have their isEnabled property set to true.