### PR TITLE
Count Admin/Owner distinctly

### DIFF
--- a/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
+++ b/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
@@ -60,9 +60,8 @@ class SubscriptionCore: SVTBase
 		$scope = $this.SubscriptionContext.Scope;
 
 		$SubAdmins = @();
-		$SubAdmins += $this.RoleAssignments | Where-Object { $_.RoleDefinitionName -eq 'CoAdministrator' `
-																				-or $_.RoleDefinitionName -like '*ServiceAdministrator*' `
-																				-or ($_.RoleDefinitionName -eq 'Owner' -and $_.Scope -eq $scope)}
+		$SubAdmins += $this.RoleAssignments | Where-Object { ($_.RoleDefinitionName -like '*ServiceAdministrator*' `
+																				-or $_.RoleDefinitionName -eq 'Owner') -and $_.Scope -eq $scope}
 		
 		if($this.HasGraphAPIAccess -eq $false)
 		{
@@ -112,7 +111,8 @@ class SubscriptionCore: SVTBase
 			$controlResult.VerificationResult = [VerificationResult]::Failed
 			$controlResult.AddMessage("Number of admins/owners configured at subscription scope are more than the approved limit: $($this.ControlSettings.NoOfApprovedAdmins). Total: " + $ClientSubAdmins.Count);
 		}
-		else {
+		else
+		{
 			$controlResult.AddMessage([VerificationResult]::Passed,
 										"Number of admins/owners configured at subscription scope are with in approved limit: $($this.ControlSettings.NoOfApprovedAdmins). Total: " + $ClientSubAdmins.Count);
 		}


### PR DESCRIPTION
## Description
</br>
A person cannot be a co-admin if he/she's not already an Owner on the sub - hence, removed the selection criteria of 'CoAdministrator' - in order to get each user just ONCE.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
