### PR TITLE
Bug fix for control Azure_AppService_DP_Use_CNAME_With_SSL

### DIFF
--- a/src/AzSK/Framework/Core/SVT/Services/AppService.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/AppService.ps1
@@ -100,7 +100,7 @@ class AppService: SVTBase
 		{
 			$controlResult.AddMessage([MessageData]::new("Custom domains are configured for resource " + $this.ResourceContext.ResourceName), $customHostNames);
 
-			$SSLStateNotEnabled = $this.ResourceObject.Properties.hostNameSslStates | Where-Object { (($customHostNames | Measure-Object) -contains $_.name) -and  ($_.sslState -eq 'Disabled')} | Select-Object -Property Name
+			$SSLStateNotEnabled = $this.ResourceObject.Properties.hostNameSslStates | Where-Object { ($customHostNames -contains $_.name) -and  ($_.sslState -eq 'Disabled')} | Select-Object -Property Name
 			if($null -eq $SSLStateNotEnabled)
 			{
 				$controlResult.AddMessage([VerificationResult]::Passed,


### PR DESCRIPTION
## Description
</br>
Azure_AppService_DP_Use_CNAME_With_SSL control logic was incorrectly calculating number of custom domains having SSL disabled.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
