### PR TITLE
SVT extension is not respected when multiple resource instances are used.

### DIFF
--- a/src/AzSK/Framework/Core/SVT/ServicesSecurityStatus.ps1
+++ b/src/AzSK/Framework/Core/SVT/ServicesSecurityStatus.ps1
@@ -167,7 +167,10 @@ class ServicesSecurityStatus: SVTCommandBase
 				try
 				{
 					$extensionSVTClassName = $svtClassName + "Ext";
-					$extensionSVTClassFilePath = [ConfigurationManager]::LoadExtensionFile($svtClassName);				
+					if(-not ($extensionSVTClassName -as [type]))
+					{
+						$extensionSVTClassFilePath = [ConfigurationManager]::LoadExtensionFile($svtClassName); 
+					}	
 					if([string]::IsNullOrWhiteSpace($extensionSVTClassFilePath))
 					{
 						$svtObject = New-Object -TypeName $svtClassName -ArgumentList $this.SubscriptionContext.SubscriptionId, $_


### PR DESCRIPTION
## Description
</br>
 SVT extension is not respected when multiple resource instances are used. After the first resource is scanned, it is unable to fetch the extended control method as it was already loaded in the first resource scan. 
## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
