### PR TITLE
Bug fixes for controls and one P2 bug

### DIFF
--- a/src/AzSK/Framework/Abstracts/AzSKRoot.ps1
+++ b/src/AzSK/Framework/Abstracts/AzSKRoot.ps1
@@ -54,8 +54,14 @@ class AzSKRoot: EventBase
 		{
 		    if(($currentContext.Subscription.Id -ne $this.SubscriptionContext.SubscriptionId) -and ($this.SubscriptionContext.SubscriptionId -ne [Constants]::BlankSubscriptionId))
 			{
-				$currentContext = Set-AzContext -SubscriptionId $this.SubscriptionContext.SubscriptionId -ErrorAction Stop   
-        
+				try 
+				{
+					$currentContext = Set-AzContext -SubscriptionId $this.SubscriptionContext.SubscriptionId -ErrorAction Stop   
+				}
+				catch 
+				{
+					throw [SuppressedException] ("Please provide a valid tenant or a valid subscription.​") 
+				}
 				    
 				# $currentContext will contain the desired subscription (or $null if id is wrong or no permission)
 				if ($null -eq $currentContext)

--- a/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
@@ -44,13 +44,15 @@ class NotificationHub: SVTBase
                                                 | Select-Object -Property Name, Rights  
         if((($accessPolicieswithManageRights | Measure-Object).Count -eq 1) -and ($accessPolicieswithManageRights.Name -eq "DefaultFullSharedAccessSignature")) {
             $controlResult.AddMessage([VerificationResult]::Verify,
-                            [MessageData]::new("Only the default authorization rule has 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                            [MessageData]::new("Only the default authorization rule has 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]. Please ensure that these authorization rules are not used at the client end."  , 
                             $accessPolicieswithManageRights));
+
+            $controlResult.SetStateData("Access policy with 'Manage' rights",$accessPolicieswithManageRights);
         }
         else {
                 if($null -ne $accessPolicieswithManageRights){
-                    $controlResult.AddMessage([VerificationResult]::Failed,
-                                            [MessageData]::new("Authorization rules having 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                    $controlResult.AddMessage([VerificationResult]::Verify,
+                                            [MessageData]::new("Authorization rules having 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]. Please ensure that these authorization rules are not used at the client end."  , 
                                             $accessPolicieswithManageRights));
             
                     $controlResult.SetStateData("Access policies with 'Manage' rights",$accessPolicieswithManageRights);

--- a/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
@@ -36,31 +36,31 @@ class NotificationHub: SVTBase
 	hidden [ControlResult] CheckAuthorizationRule([ControlResult] $controlResult)
 	{
 		$resourceName = ($this.ResourceContext.ResourceName.Split("/")[1]);
-	 $accessPolicieswithManageRights =  (Get-AzNotificationHubAuthorizationRules `
-                                            -ResourceGroup $this.ResourceContext.ResourceGroupName `
-                                            -Namespace $this.NamespaceObject.Name `
-                                            -NotificationHub $resourceName) `
-                                            | Where-Object Rights -Contains "Manage" `
-                                            | Select-Object -Property Name, Rights  
-    if((($accessPolicieswithManageRights | Measure-Object).Count -eq 1) -and ($accessPolicieswithManageRights.Name -eq "DefaultFullSharedAccessSignature")) {
-       $controlResult.AddMessage([VerificationResult]::Verify,
-                           [MessageData]::new("Only the default authorization rule has 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
-                           $accessPolicieswithManageRights));
-    }
-    else {
-            if($null -ne $accessPolicieswithManageRights){
-		        $controlResult.AddMessage([VerificationResult]::Failed,
-                                          [MessageData]::new("Authorization rules having 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
-                                           $accessPolicieswithManageRights));
-        
-                $controlResult.SetStateData("Access policies with 'Manage' rights",$accessPolicieswithManageRights);
-            }
-            else{
-                $controlResult.AddMessage([VerificationResult]::Passed,
-                                          [MessageData]::new("No authorization rules found with 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
-                                          $accessPolicieswithManageRights));
-            }
-    }
+        $accessPolicieswithManageRights =  (Get-AzNotificationHubAuthorizationRules `
+                                                -ResourceGroup $this.ResourceContext.ResourceGroupName `
+                                                -Namespace $this.NamespaceObject.Name `
+                                                -NotificationHub $resourceName) `
+                                                | Where-Object Rights -Contains "Manage" `
+                                                | Select-Object -Property Name, Rights  
+        if((($accessPolicieswithManageRights | Measure-Object).Count -eq 1) -and ($accessPolicieswithManageRights.Name -eq "DefaultFullSharedAccessSignature")) {
+        $controlResult.AddMessage([VerificationResult]::Passed,
+                            [MessageData]::new("Only the default authorization rule has 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                            $accessPolicieswithManageRights));
+        }
+        else {
+                if($null -ne $accessPolicieswithManageRights){
+                    $controlResult.AddMessage([VerificationResult]::Failed,
+                                            [MessageData]::new("Authorization rules having 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                                            $accessPolicieswithManageRights));
+            
+                    $controlResult.SetStateData("Access policies with 'Manage' rights",$accessPolicieswithManageRights);
+                }
+                else{
+                    $controlResult.AddMessage([VerificationResult]::Passed,
+                                            [MessageData]::new("No authorization rules found with 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                                            $accessPolicieswithManageRights));
+                }
+        }
 
 		return $controlResult;
 	}

--- a/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
@@ -42,18 +42,24 @@ class NotificationHub: SVTBase
                                             -NotificationHub $resourceName) `
                                             | Where-Object Rights -Contains "Manage" `
                                             | Select-Object -Property Name, Rights  
-
-    if($null -ne $accessPolicieswithManageRights){
-		$controlResult.AddMessage([VerificationResult]::Failed,
-                                  [MessageData]::new("Authorization rules having 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
-                                   $accessPolicieswithManageRights));
-
-        $controlResult.SetStateData("Access policies with 'Manage' rights",$accessPolicieswithManageRights);
+    if((($accessPolicieswithManageRights | Measure-Object).Count -eq 1) -and ($accessPolicieswithManageRights.Name -eq "DefaultFullSharedAccessSignature")) {
+       $controlResult.AddMessage([VerificationResult]::Verify,
+                           [MessageData]::new("Only the default authorization rule has 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                           $accessPolicieswithManageRights));
     }
-    else{
-        $controlResult.AddMessage([VerificationResult]::Passed,
-                                  [MessageData]::new("No authorization rules found with 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
-                                  $accessPolicieswithManageRights));
+    else {
+            if($null -ne $accessPolicieswithManageRights){
+		        $controlResult.AddMessage([VerificationResult]::Failed,
+                                          [MessageData]::new("Authorization rules having 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                                           $accessPolicieswithManageRights));
+        
+                $controlResult.SetStateData("Access policies with 'Manage' rights",$accessPolicieswithManageRights);
+            }
+            else{
+                $controlResult.AddMessage([VerificationResult]::Passed,
+                                          [MessageData]::new("No authorization rules found with 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
+                                          $accessPolicieswithManageRights));
+            }
     }
 
 		return $controlResult;

--- a/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/NotificationHub.ps1
@@ -43,7 +43,7 @@ class NotificationHub: SVTBase
                                                 | Where-Object Rights -Contains "Manage" `
                                                 | Select-Object -Property Name, Rights  
         if((($accessPolicieswithManageRights | Measure-Object).Count -eq 1) -and ($accessPolicieswithManageRights.Name -eq "DefaultFullSharedAccessSignature")) {
-        $controlResult.AddMessage([VerificationResult]::Passed,
+            $controlResult.AddMessage([VerificationResult]::Verify,
                             [MessageData]::new("Only the default authorization rule has 'Manage' security claim access rights for resource -  ["+ $this.ResourceContext.ResourceName +"]"  , 
                             $accessPolicieswithManageRights));
         }

--- a/src/AzSK/Framework/Core/SVT/Services/ServiceBus.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/ServiceBus.ps1
@@ -114,21 +114,13 @@ class ServiceBus: SVTBase
 		$isControlFailed = $false
 		#region "NameSpace"
 
-		if(($this.NamespacePolicies | Measure-Object).count -gt 1)
-		{
-			$controlResult.AddMessage([VerificationResult]::Failed, [MessageData]::new("Authorization rules for namespace - ["+ $this.ResourceContext.ResourceName +"]. All the authorization rules except 'RootManageSharedAccessKey' must be removed from namespace level. Also validate that 'RootManageSharedAccessKey' authorization rule must not be used at Queue/Topic level to send and receive messages.", 
-				$this.NamespacePolicies));   	
+		if((($this.NamespacePolicies | Measure-Object).count -eq 1) -and (($this.NamespacePolicies.Id.substring($this.NamespacePolicies.Id.Length-25, 25) -eq "RootManageSharedAccessKey"))) {
+			$controlResult.AddMessage([VerificationResult]::Passed, [MessageData]::new("Only default authorization rule present for namespace - ["+ $this.ResourceContext.ResourceName +"].", 
+			$this.NamespacePolicies)); 
 		}
-		else
-		{
-            if((($this.NamespacePolicies | Measure-Object).count -eq 1) -and (($this.NamespacePolicies.Id.substring($this.NamespacePolicies.Id.Length-25, 25) -eq "RootManageSharedAccessKey"))) {
-                $controlResult.AddMessage([VerificationResult]::Passed, [MessageData]::new("Only default authorization rule present for namespace - ["+ $this.ResourceContext.ResourceName +"].", 
-				$this.NamespacePolicies)); 
-            }
-            else {
-                $controlResult.AddMessage([VerificationResult]::Verify, [MessageData]::new("Authorization rules for namespace - ["+ $this.ResourceContext.ResourceName +"]. Validate that these rules must not be used at Queue/Topic level to send and receive messages.", 
-				$this.NamespacePolicies));   	
-            }
+		else {
+			$controlResult.AddMessage([VerificationResult]::Failed, [MessageData]::new("Authorization rules for namespace - ["+ $this.ResourceContext.ResourceName +"]. All the authorization rules except 'RootManageSharedAccessKey' must be removed from namespace level. Also validate that 'RootManageSharedAccessKey' authorization rule must not be used at Queue/Topic level to send and receive messages.", 
+			$this.NamespacePolicies)); 
 		}
 
 		$controlResult.SetStateData("Authorization rules for namespace entities", $this.NamespacePolicies);

--- a/src/AzSK/Framework/Core/SVT/Services/ServiceBus.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/ServiceBus.ps1
@@ -121,8 +121,14 @@ class ServiceBus: SVTBase
 		}
 		else
 		{
-			$controlResult.AddMessage([VerificationResult]::Verify, [MessageData]::new("Authorization rules for namespace - ["+ $this.ResourceContext.ResourceName +"]. Validate that these rules must not be used at Queue/Topic level to send and receive messages.", 
+            if((($this.NamespacePolicies | Measure-Object).count -eq 1) -and (($this.NamespacePolicies.Id.substring($this.NamespacePolicies.Id.Length-25, 25) -eq "RootManageSharedAccessKey"))) {
+                $controlResult.AddMessage([VerificationResult]::Passed, [MessageData]::new("Only default authorization rule present for namespace - ["+ $this.ResourceContext.ResourceName +"].", 
+				$this.NamespacePolicies)); 
+            }
+            else {
+                $controlResult.AddMessage([VerificationResult]::Verify, [MessageData]::new("Authorization rules for namespace - ["+ $this.ResourceContext.ResourceName +"]. Validate that these rules must not be used at Queue/Topic level to send and receive messages.", 
 				$this.NamespacePolicies));   	
+            }
 		}
 
 		$controlResult.SetStateData("Authorization rules for namespace entities", $this.NamespacePolicies);


### PR DESCRIPTION
## Description
</br>

 - Fixed the logic for the control Azure_NotificationHub_AuthZ_Dont_Use_Manage_Access_Permission
 - Fixed the logic for the control Azure_ServiceBus_AuthZ_Dont_Use_Policies_At_SB_Namespace
 - Bug fix for [P2 bug](https://microsoftit.visualstudio.com/OneITVSO/_workitems/edit/4209791/) regarding error handling when running scans with invalid subscription or tenant.  

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
