### PR TITLE
Fixing framework behaviour when no baseline/preview baseline controls are defined

### DIFF
--- a/src/AzSK/Framework/Core/SVT/ServicesSecurityStatus.ps1
+++ b/src/AzSK/Framework/Core/SVT/ServicesSecurityStatus.ps1
@@ -333,6 +333,10 @@ class ServicesSecurityStatus: SVTCommandBase
 
 			}		
 		}
+		elseif (($baselineControlsDetails.ResourceTypeControlIdMappingList | Measure-Object).Count -eq 0 -and $this.UseBaselineControls) 
+		{
+			throw ([SuppressedException]::new(("There are no baseline controls defined for this policy. No controls will be scanned."), [SuppressedExceptionType]::Generic))
+		}
 
 		#Preview Baseline Controls
 		$previewBaselineControlsDetails = $partialScanMngr.GetPreviewBaselineControlDetails()
@@ -352,6 +356,11 @@ class ServicesSecurityStatus: SVTCommandBase
 				$this.ControlIds += $controlIds;
 			}			
 		}
+		elseif (($previewBaselineControlsDetails.ResourceTypeControlIdMappingList | Measure-Object).Count -eq 0 -and $this.UsePreviewBaselineControls) 
+		{
+			throw ([SuppressedException]::new(("There are no preview baseline controls defined for this policy. No controls will be scanned."), [SuppressedExceptionType]::Generic))
+		}
+
 
 		if(($ResourcesWithBaselineFilter | Measure-Object).Count -gt 0)
 		{

--- a/src/AzSK/Framework/Core/SVT/SubscriptionSecurityStatus.ps1
+++ b/src/AzSK/Framework/Core/SVT/SubscriptionSecurityStatus.ps1
@@ -107,6 +107,10 @@ class SubscriptionSecurityStatus: SVTCommandBase
 				$this.ControlIds = $controlIds;			
 			}
 		}
+		elseif (($baselineControlsDetails.SubscriptionControlIdList | Measure-Object).Count -eq 0 -and $this.UseBaselineControls) 
+		{
+			throw ([SuppressedException]::new(("There are no baseline controls defined for this policy. No controls will be scanned."), [SuppressedExceptionType]::Generic))
+		}
 
 		$previewBaselineControlsDetails = $partialScanMngr.GetPreviewBaselineControlDetails()
 		#If Scan source is in supported sources or baselineControls switch is available
@@ -119,6 +123,10 @@ class SubscriptionSecurityStatus: SVTCommandBase
 			{
 				$this.ControlIds += $controlIds;			
 			}
+		}
+		elseif (($previewBaselineControlsDetails.SubscriptionControlIdList | Measure-Object).Count -eq 0 -and $this.UsePreviewBaselineControls) 
+		{
+			throw ([SuppressedException]::new(("There are no preview baseline controls defined for this policy. No controls will be scanned."), [SuppressedExceptionType]::Generic))
 		}
 	}	
 }


### PR DESCRIPTION
## Description
</br>
 Happened in Contoso Org policy. Even when no baseline or preview baseline controls are defined, on passing the upbc/ubc switch, all controls would get scanned which should not be the case. That has now been handled appropriately.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
