### PR TITLE
Changes for mix up scenario to install RM dependencies 

### DIFF
--- a/src/AzSK/Framework/Configurations/ContinuousAssurance/RunbookCoreSetupAzureRm.ps1
+++ b/src/AzSK/Framework/Configurations/ContinuousAssurance/RunbookCoreSetupAzureRm.ps1
@@ -386,7 +386,36 @@ try
 	$AzSKPSGalleryUrl = "https://www.powershellgallery.com"
 	$PublicPSGalleryUrl = "https://www.powershellgallery.com"
 	$isBaseProfileModule =  (Get-Module -Name AzureRm.Profile).Version.Major -lt 5
-	if(-not $isBaseProfileModule)
+	$tags=@{};
+	$RunbookVersion="";
+	try
+	{
+		$azskResourceGroup = Get-AzureRmResourceGroup -Name $AutomationAccountRG -ErrorAction SilentlyContinue;
+		if(($azskResourceGroup | Measure-Object).Count -gt 0)
+		{
+			$tags = $azskResourceGroup.Tags;
+			if($tags.ContainsKey("AzSKVersion"))
+			{
+				$RunbookVersion = $tags['AzSKCARunbookVersion']
+			}
+			
+		}
+	}
+	catch
+	{
+		$azskResourceGroup = Get-AzResourceGroup -Name $AutomationAccountRG -ErrorAction SilentlyContinue;
+		if(($azskResourceGroup | Measure-Object).Count -gt 0)
+		{
+			$tags = $azskResourceGroup.Tags;
+			if($tags.ContainsKey("AzSKVersion"))
+			{
+				$RunbookVersion = $tags['AzSKCARunbookVersion']
+			}
+			
+		}
+	}
+
+	if(-not $isBaseProfileModule -or ($RunbookVersion -eq "3.1803.0") )
 	{
 		$setupTimer = [System.Diagnostics.Stopwatch]::StartNew();
 		PublishEvent -EventName "CA Setup Started"

--- a/src/OSSConfiguration/RunbookCoreSetupAzureRm.ps1
+++ b/src/OSSConfiguration/RunbookCoreSetupAzureRm.ps1
@@ -386,7 +386,36 @@ try
 	$AzSKPSGalleryUrl = "https://www.powershellgallery.com"
 	$PublicPSGalleryUrl = "https://www.powershellgallery.com"
 	$isBaseProfileModule =  (Get-Module -Name AzureRm.Profile).Version.Major -lt 5
-	if(-not $isBaseProfileModule)
+	$tags=@{};
+	$RunbookVersion="";
+	try
+	{
+		$azskResourceGroup = Get-AzureRmResourceGroup -Name $AutomationAccountRG -ErrorAction SilentlyContinue;
+		if(($azskResourceGroup | Measure-Object).Count -gt 0)
+		{
+			$tags = $azskResourceGroup.Tags;
+			if($tags.ContainsKey("AzSKVersion"))
+			{
+				$RunbookVersion = $tags['AzSKCARunbookVersion']
+			}
+			
+		}
+	}
+	catch
+	{
+		$azskResourceGroup = Get-AzResourceGroup -Name $AutomationAccountRG -ErrorAction SilentlyContinue;
+		if(($azskResourceGroup | Measure-Object).Count -gt 0)
+		{
+			$tags = $azskResourceGroup.Tags;
+			if($tags.ContainsKey("AzSKVersion"))
+			{
+				$RunbookVersion = $tags['AzSKCARunbookVersion']
+			}
+			
+		}
+	}
+
+	if(-not $isBaseProfileModule -or ($RunbookVersion -eq "3.1803.0") )
 	{
 		$setupTimer = [System.Diagnostics.Stopwatch]::StartNew();
 		PublishEvent -EventName "CA Setup Started"


### PR DESCRIPTION
## Description
</br>
Currently we check for the base version of RM.Profile  if it is greater than the default, it then only installs the RM dependencies, which is blocking the users trying to install older version of AzSK as they would have newer profile version.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
