### PR TITLE
Fixed Controls error when AppService is Stopped -

### DIFF
--- a/src/AzSK/Framework/Core/SVT/Services/AppService.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/AppService.ps1
@@ -130,6 +130,11 @@ class AppService: SVTBase
 			$controlResult.AddMessage([VerificationResult]::Manual,
                                     [MessageData]::new("Control can not be validated due to insufficient access permission on resource"));
 		}
+		elseif($this.WebAppDetails.State -eq "Stopped")
+		{
+			$controlResult.AddMessage([VerificationResult]::Manual,
+                                    [MessageData]::new("Control can not be validated as the resource is in 'Stopped' state."));
+		}
 		else
 		{
 			#Checks if functions app present
@@ -471,12 +476,17 @@ class AppService: SVTBase
     hidden [ControlResult] CheckFunctionsAppHttpCertificateSSL([ControlResult] $controlResult)
 	{	
 			if($this.IsReaderRole)
-				{
-					#Setting this property ensures that this control result wont be considered for the central telemetry. As control doesnt have the required permissions
-					$controlResult.CurrentSessionContext.Permissions.HasRequiredAccess = $false;
-					$controlResult.AddMessage([VerificationResult]::Manual,
-                                    [MessageData]::new("Control can not be validated due to insufficient access permission on resource"));
-				}
+			{
+				#Setting this property ensures that this control result wont be considered for the central telemetry. As control doesnt have the required permissions
+				$controlResult.CurrentSessionContext.Permissions.HasRequiredAccess = $false;
+				$controlResult.AddMessage([VerificationResult]::Manual,
+                                [MessageData]::new("Control can not be validated due to insufficient access permission on resource"));
+			}
+			elseif($this.WebAppDetails.State -eq "Stopped")
+			{
+				$controlResult.AddMessage([VerificationResult]::Manual,
+                                [MessageData]::new("Control can not be validated as the resource is in 'Stopped' state."));
+			}
 			else
 				{
 				$ResourceAppIdURI = [WebRequestHelper]::GetServiceManagementUrl()


### PR DESCRIPTION
1. Azure_AppService_AuthN_Use_AAD_for_Client_AuthN
2. Azure_AppService_DP_Dont_Allow_HTTP_Access_Fn

## Description
</br>
 Brief description of the requested change.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
