### PR TITLE
Disabling anonymous storage access for ADLS Gen2 with HNS enabled. - Updated

### DIFF
--- a/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
@@ -75,6 +75,13 @@ class Storage: SVTBase
 		$resource = Get-AzResource -ResourceId $this.ResourceContext.ResourceId;
 		#Disabling the control 'Azure_Storage_AuthN_Dont_Allow_Anonymous' for Data Lake Storage Gen2 resources with hierarchical namespace accounts enabled as blob storage is not currently supported.
 
+		if(([Helpers]::CheckMember($resource.Properties, "isHnsEnabled") -and ($resource.Properties.isHnsEnabled -eq $true)))
+		{
+
+             $result = $result | Where-Object {$_.Tags -notcontains "HNSDisabled" }
+
+		}
+		
 		return $result;
 	}
 

--- a/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
@@ -77,11 +77,9 @@ class Storage: SVTBase
 
 		if(([Helpers]::CheckMember($resource.Properties, "isHnsEnabled") -and ($resource.Properties.isHnsEnabled -eq $true)))
 		{
-
-             $result = $result | Where-Object {$_.Tags -notcontains "HNSDisabled" }
-
+			$result = $result | Where-Object {$_.Tags -notcontains "HNSDisabled"}
 		}
-		
+
 		return $result;
 	}
 


### PR DESCRIPTION
Disabling the control 'Azure_Storage_AuthN_Dont_Allow_Anonymous' for Data Lake Storage Gen2 resources with hierarchical namespace accounts enabled as blob storage is not currently supported.