### PR TITLE
Whitelisting AzSKContinuousAssurance variables

### DIFF
--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -287,7 +287,7 @@
   },
   "Automation": {
     "WebhookValidityInDays": 60,
-    "variablesToSkip": ["AppResourceGroupNames", "ReportsStorageAccountName", "UpdateToLatestAzSKVersion", "OMSSharedKey", "OMSWorkspaceId", "AltOMSWorkspaceId", "AltOMSWorkspaceId", "WebhookAuthZHeaderName", "WebhookUrl"]
+    "variablesToSkip": ["AppResourceGroupNames", "ReportsStorageAccountName", "UpdateToLatestAzSKVersion", "OMSSharedKey", "OMSWorkspaceId", "AltOMSWorkspaceId", "AltOMSSharedKey", "WebhookAuthZHeaderName", "WebhookUrl"]
   },
   "BaselineControls": {
     "ResourceTypeControlIdMappingList": [

--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -287,7 +287,7 @@
   },
   "Automation": {
     "WebhookValidityInDays": 60,
-    "variablesToSkip": []
+    "variablesToSkip": ["AppResourceGroupNames", "ReportsStorageAccountName", "UpdateToLatestAzSKVersion", "OMSSharedKey", "OMSWorkspaceId", "AltOMSWorkspaceId", "AltOMSWorkspaceId", "WebhookAuthZHeaderName", "WebhookUrl"]
   },
   "BaselineControls": {
     "ResourceTypeControlIdMappingList": [


### PR DESCRIPTION
I have updated the whitelist of variables to skipped as a part of the scan of the control 'Azure_Automation_DP_Use_Encrypted_Variables'. This whitelist applies only to the CA present in AzSKRG.