### PR TITLE
new control for key vault and perf bug fix

### DIFF
--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -367,5 +367,7 @@
     "Medium": "Medium",
     "Low": "Low"
   },
-  "MandatoryTags":[]
+  "MandatoryTags":[
+  
+  ]
 }

--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -6,7 +6,8 @@
     "SecretRotationDuration_Days": 180,
     "KeyType": "RSA-HSM",
     "ADAppCredentialTypeCrt": "AsymmetricX509Cert",
-    "ADAppCredentialTypePwd": "Password"
+    "ADAppCredentialTypePwd": "Password",
+    "MaxRecommendedVersions": 3
   },
   "SqlServer": {
     "AuditRetentionPeriod_Min": 365,
@@ -366,8 +367,5 @@
     "Medium": "Medium",
     "Low": "Low"
   },
-  "MandatoryTags":[
-   
-  ]
-
+  "MandatoryTags":[]
 }

--- a/src/AzSK/Framework/Configurations/SVT/Services/KeyVault.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/KeyVault.json
@@ -247,6 +247,24 @@
          "KeyVault"
       ],
       "Enabled": true
-   }
+   },
+   {
+    "ControlID": "Azure_KeyVault_Avoid_Excessive_Versions_Keys_Secrets",
+    "Description": "Too many versions of keys or secrets should not be in use.",
+    "Id": "KeyVault240",
+    "ControlSeverity": "Medium",
+    "Automated": "Yes",
+    "MethodName": "CheckExcessVersions",
+    "Rationale": "Having too many active versions can lead to increased complexity of solutions due to difficulty of tracking what is in use where, indirectly leading to security vulnerability due to oversight. Additionally, it can also adversely affect performance and availability.",
+    "Recommendation": "Disable older versions of keys and secrets that are no longer required. Go to the Azure Portal > Key Vault > Settings > Keys or Secrets. Select the key or secret that has too many versions, and choose the version that needs to be disabled. Set 'Enabled' attribute as 'No'. For more on the Azure Key Vault service limits, refer: https://docs.microsoft.com/en-us/azure/key-vault/key-vault-service-limits",
+    "Tags": [
+      "SDL",
+      "TCP",
+      "Automated",
+      "KeySecretPermissions",
+      "KeyVault"
+    ],
+    "Enabled": true
+  }
                  ]
 }

--- a/src/AzSK/Framework/Core/SVT/Services/KeyVault.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/KeyVault.ps1
@@ -120,15 +120,16 @@ class KeyVault: SVTBase
 						$keysResult = @();
 						$keysResult += Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -ErrorAction Stop | 
 										Where-Object { $_.Enabled -eq $true };
-
+						
 						$this.AllEnabledKeys = @();
 						if($keysResult.Count -gt 0) 
 						{
 							$keysResult | ForEach-Object {
 								Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -Name $_.Name -IncludeVersions |
 								Where-Object { $_.Enabled -eq $true } | 
+                                Select-Object -First 3 |
 								ForEach-Object {
-									$this.AllEnabledKeys += Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -Name $_.Name -Version $_.Version ;
+                                    $this.AllEnabledKeys += Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -Name $_.Name -Version $_.Version ;
 								}
 							}
 						}
@@ -178,6 +179,7 @@ class KeyVault: SVTBase
 						$secretsResult | ForEach-Object {
 							Get-AzKeyVaultSecret -VaultName $this.ResourceContext.ResourceName -Name $_.Name -IncludeVersions |
 							Where-Object { $_.Enabled -eq $true } | 
+                            Select-Object -First 3 |
 							ForEach-Object {
 								$this.AllEnabledSecrets += Get-AzKeyVaultSecret -VaultName $this.ResourceContext.ResourceName -Name $_.Name -Version $_.Version ;
 							}
@@ -535,6 +537,171 @@ class KeyVault: SVTBase
 
 		return $controlResult;
 		
+	}
+
+	hidden [PSObject[]] CheckExcessKeyVersions([ControlResult] $controlResult)
+	{
+		$allExcessVersionKeys = @();
+
+		if($this.HasFetchKeysPermissions -eq $true)
+		{
+				try
+				{
+					$keysResult = @();
+					$keysResult += Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -ErrorAction Stop | 
+									Where-Object { $_.Enabled -eq $true };
+
+					if($keysResult.Count -gt 0) 
+					{
+						$keysResult | ForEach-Object {
+							$count = 0
+							Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -Name $_.Name -IncludeVersions |
+							Where-Object { $_.Enabled -eq $true } | 
+							ForEach-Object {
+								if ($count -eq 3) 
+								{
+									$allExcessVersionKeys += Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -Name $_.Name;
+									break
+								}
+								$count++
+							}
+						}
+					}
+				}
+				catch
+				{
+					if ($_.Exception.GetType().FullName -eq "Microsoft.Azure.KeyVault.Models.KeyVaultErrorException")
+					{
+						$controlResult.AddMessage([VerificationResult]::Manual,
+							[MessageData]::new("Access denied: Read access is required on Key Vault Keys."));
+					}
+					else
+					{
+						throw $_
+					}
+				}
+		}
+		else
+		{
+			$controlResult.CurrentSessionContext.Permissions.HasRequiredAccess = $false;
+			$controlResult.AddMessage([VerificationResult]::Manual,
+				[MessageData]::new("Control can not be validated due to insufficient access permission on keys"));
+		}
+
+		return $allExcessVersionKeys;
+	}
+
+	hidden [PSObject[]] CheckExcessSecretVersions([ControlResult] $controlResult)
+	{
+		$allExcessVersionSecrets = @();
+
+		if($this.HasFetchSecretsPermissions -eq $true)
+		{
+				try
+				{
+					$secretsResult = @();
+					$secretsResult += Get-AzKeyVaultSecret -VaultName $this.ResourceContext.ResourceName -ErrorAction Stop | 
+									Where-Object { $_.Enabled -eq $true };
+
+					if($secretsResult.Count -gt 0) 
+					{
+						$secretsResult | ForEach-Object {
+							$count = 0
+							Get-AzKeyVaultSecret -VaultName $this.ResourceContext.ResourceName -Name $_.Name -IncludeVersions |
+							Where-Object { $_.Enabled -eq $true } | 
+							ForEach-Object {
+								if ($count -eq 3) 
+								{
+									$allExcessVersionSecrets += Get-AzKeyVaultSecret -VaultName $this.ResourceContext.ResourceName -Name $_.Name;
+									break
+								}
+								$count++
+							}
+						}
+					}
+				}
+				catch
+				{
+					if ($_.Exception.GetType().FullName -eq "Microsoft.Azure.KeyVault.Models.KeyVaultErrorException")
+					{
+						$controlResult.AddMessage([VerificationResult]::Manual,
+							[MessageData]::new("Access denied: Read access is required on Key Vault Secrets."));
+					}
+					else
+					{
+						throw $_
+					}
+				}
+		}
+		else
+		{
+			$controlResult.CurrentSessionContext.Permissions.HasRequiredAccess = $false;
+			$controlResult.AddMessage([VerificationResult]::Manual,
+				[MessageData]::new("Control can not be validated due to insufficient access permission on secrets"));
+		}
+
+		return $allExcessVersionSecrets;
+	}
+
+	hidden [ControlResult] CheckExcessVersions([ControlResult] $controlResult)
+	{
+		$excessKeys = $this.CheckExcessKeyVersions($controlResult);
+		$excessSecrets = $this.CheckExcessSecretVersions($controlResult);
+		$excessVersionResources = @();
+
+		if ($excessKeys.Count -ne 0 -or $excessSecrets.Count -ne 0) 
+		{
+			if ($excessKeys.Count -ne 0) 
+			{
+				$excessKeysDetails = $excessKeys | Select-Object Name, Version -ExpandProperty Attributes;
+				$excessVersionResources += $excessKeysDetails
+				$controlResult.AddMessage([VerificationResult]::Failed,
+					[MessageData]::new("Following Keys have more than 3 enabled versions."  , 
+							($excessKeysDetails )));	
+			}
+			if ($excessSecrets.Count -ne 0) 
+			{
+				$excessSecretsDetails = $excessSecrets | Select-Object Name, Version -ExpandProperty Attributes;
+				$excessVersionResources += $excessSecretsDetails
+				$controlResult.AddMessage([VerificationResult]::Failed,
+					[MessageData]::new("Following Secrets have more than 3 enabled versions."  , 
+							($excessSecretsDetails )));	
+			}	
+
+			if($excessVersionResources.Count -gt 0)
+			{
+                $excessVersionResourcesDetails = $excessVersionResources | Select-Object -Property Name, Version, Enabled, Created, Updated, RecoveryLevel
+				$controlResult.SetStateData("Following keys and secrets have more than 3 enabled versions.", 
+				    ($excessVersionResourcesDetails));
+			}
+
+		}
+		else 
+		{
+			$keysResult = @();
+			$keysResult += Get-AzKeyVaultKey -VaultName $this.ResourceContext.ResourceName -ErrorAction Stop | 
+							Where-Object { $_.Enabled -eq $true };
+			
+			$secretsResult = @();
+			$secretsResult += Get-AzKeyVaultSecret -VaultName $this.ResourceContext.ResourceName -ErrorAction Stop | 
+							Where-Object { $_.Enabled -eq $true };
+		
+			if ($keysResult.Count -eq 0 -and $secretsResult.Count -eq 0) 
+			{
+				$controlResult.AddMessage( [VerificationResult]::Passed,
+				[MessageData]::new("No Keys and Secrets are enabled for Key Vault - ["+ $this.ResourceContext.ResourceName +"]"));   
+			}
+			else 
+			{
+				if ($excessKeys.Count -eq 0 -and $excessSecrets.Count -eq 0)
+				{
+					$controlResult.AddMessage( [VerificationResult]::Passed,
+					[MessageData]::new("All Keys and Secrets have at the most 3 versions enabled for Key Vault - ["+ $this.ResourceContext.ResourceName +"]"));   
+				}		
+			}
+		}
+
+		return $controlResult
 	}
 }
 


### PR DESCRIPTION
## Description
</br>
 Performance issue in key vault controls that used FetchAllEnabledSecretsWithVersions and FetchAllEnabledKeysWithVersions has been fixed, and a new control has been added to check if a key or secret has too many versions.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
