### PR TITLE
[Bug]: Controls in 'Error' status should not be allowed for attestation

### DIFF
--- a/src/AzSK.Framework/Abstracts/SVTBase.ps1
+++ b/src/AzSK.Framework/Abstracts/SVTBase.ps1
@@ -974,7 +974,8 @@ class SVTBase: AzSKRoot
 		{
 			$expiryIndays = $this.CalculateExpirationInDays([SVTEventContext] $eventcontext,[ControlState] $controlState);
 			#Validate if expiry period is passed
-			if($expiryIndays -ne -1 -and $controlState.State.AttestedDate.AddDays($expiryIndays) -lt [DateTime]::UtcNow)
+			#Added a condition so as to expire attested controls that were in 'Error' state.
+			if(($expiryIndays -ne -1 -and $controlState.State.AttestedDate.AddDays($expiryIndays) -lt [DateTime]::UtcNow) -or ($controlState.ActualVerificationResult -eq [VerificationResult]::Error))
 			{
 				return $false
 			}

--- a/src/AzSK/Framework/Core/SVT/SVTControlAttestation.ps1
+++ b/src/AzSK/Framework/Core/SVT/SVTControlAttestation.ps1
@@ -359,7 +359,7 @@ class SVTControlAttestation
 							[ControlResult[]] $matchedControlResults = @();
 							$controlItem.ControlResults | ForEach-Object {
 								$controlResult = $_
-								if($controlResult.ActualVerificationResult -ne [VerificationResult]::Passed)
+								if($controlResult.ActualVerificationResult -ne [VerificationResult]::Passed -and $controlResult.ActualVerificationResult -ne [VerificationResult]::Error)
 								{
 									if($this.AttestControlsChoice -eq [AttestControls]::All)
 									{


### PR DESCRIPTION
## Description
</br>
Previously controls that reported 'Error' state could be attested. With these changes in place attestation of controls in 'Error' state would not be allowed.
Further if someone had previously attested the controls that were actually in 'Error' state, there attestation would expire.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
