### PR TITLE
[Bug]: 'Azure_EventHub_AuthZ_Use_Min_Permissions_Access_Policies' always goes in 'Verify'

### DIFF
--- a/src/AzSK/Framework/Core/SVT/Services/EventHub.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/EventHub.ps1
@@ -163,8 +163,6 @@ class EventHub: SVTBase
 		}
         
 		#endregion
-           
-		$controlResult.VerificationResult = [VerificationResult]::Verify;
 
 		return $controlResult;
 	}


### PR DESCRIPTION
## Description
</br>
Removed extra code that caused the control to result in 'Verify' state overwriting the correct state

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
