### PR TITLE
Bug fix: Removed IOP/UOP/GOP commands dependency on org-policy tag.

### DIFF
--- a/src/AzSK.Framework/Helpers/CommandHelper.ps1
+++ b/src/AzSK.Framework/Helpers/CommandHelper.ps1
@@ -158,18 +158,21 @@ class CommandHelper
             Noun = "AzSKOrganizationPolicy";
             ShortName = "IOP";
 			IsLatestRequired = $false;
+			IsOrgPolicyRequired = $false;
         },
 		[CommandDetails]@{
             Verb = "Update";
             Noun = "AzSKOrganizationPolicy";
             ShortName = "UOP";
 			IsLatestRequired = $false;
+			IsOrgPolicyRequired = $false;
 		},
 		[CommandDetails]@{
             Verb = "Get";
             Noun = "AzSKOrganizationPolicyStats";
             ShortName = "GOP";
 			IsLatestRequired = $false;
+			IsOrgPolicyRequired = $false;
         },
 		[CommandDetails]@{
             Verb = "Get";

--- a/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
+++ b/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
@@ -308,7 +308,7 @@ class ConfigurationHelper {
 	#Need to rethink on this function logic
 	hidden static [PSObject] LoadModuleJsonFile([string] $fileName) {
 	
-	 $rootConfigPath = (Get-Item $PSScriptRoot).Parent.FullName + "\Configurations\";
+	 $rootConfigPath = (Get-Item $PSScriptRoot).Parent.Parent.FullName + "\AzSK\Framework\Configurations\";
      $filePath = (Get-ChildItem $rootConfigPath -Name -Recurse -Include $fileName) | Select-Object -First 1 
 	 if ($filePath) {
             $fileContent = (Get-Content -Raw -Path ($rootConfigPath + $filePath)) | ConvertFrom-Json

--- a/src/AzSK.Framework/Models/CommandDetails.ps1
+++ b/src/AzSK.Framework/Models/CommandDetails.ps1
@@ -5,5 +5,6 @@ class CommandDetails
 	[string] $Verb = "";
 	[string] $ShortName = "";
 	[bool] $IsLatestRequired = $true;
-	[bool] $HasAzSKComponentWritePermission = $true
+	[bool] $IsOrgPolicyRequired = $true;
+	[bool] $HasAzSKComponentWritePermission = $true;
 }


### PR DESCRIPTION
## Description
Added ability for IOP/UOP/GOP commands to 'ignore' or avoid blocking without needing to remove the AzSKRG org-policy tag.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
