### PR TITLE
Whitelisting RGs in tagging compliance

### DIFF
--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -373,5 +373,4 @@
 
   ],
   "WhitelistedResourceGroups": []
-  ]
 }

--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -367,7 +367,7 @@
     "Low": "Low"
   },
   "MandatoryTags":[
-   
-  ]
-
+    
+  ],
+  "WhitelistedResourceGroups": ["ERNetwork-[0-9]*", "ERvNet*", "ERNetwork*"]
 }

--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -367,7 +367,7 @@
     "Low": "Low"
   },
   "MandatoryTags":[
-    
+
   ],
-  "WhitelistedResourceGroups": ["ERNetwork-[0-9]*", "ERvNet*", "ERNetwork*"]
+  "WhitelistedResourceGroups": []
 }

--- a/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
+++ b/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
@@ -968,8 +968,14 @@ class SubscriptionCore: SVTBase
 					#Check if mandatory tags list present
 			if([Helpers]::CheckMember($this.ControlSettings,"MandatoryTags") -and ($this.ControlSettings.MandatoryTags | Measure-Object).Count -ne 0)
 			{
-					$resourceGroups = Get-AzResourceGroup
-					if(($resourceGroups | Measure-Object).Count -gt 0)
+				$whitelistedResourceGroupsRegex = [System.Collections.ArrayList]::new()
+				if ([Helpers]::CheckMember($this.ControlSettings,"WhitelistedResourceGroups") -and ($this.ControlSettings.WhitelistedResourceGroups | Measure-Object).Count -ne 0) 
+				{
+					$whitelistedResourceGroupsRegex = $this.ControlSettings.WhitelistedResourceGroups						
+				}
+				$whitelistedResourceGroupsRegex = (('^' + (($whitelistedResourceGroupsRegex |foreach {[regex]::escape($_)}) –join '|') + '$')) -replace '[\\]',''
+				$resourceGroups = Get-AzResourceGroup | Where-Object {$_.ResourceGroupName -inotmatch $whitelistedResourceGroupsRegex}
+				if(($resourceGroups | Measure-Object).Count -gt 0)
 					{
 									$rgTagStatus = $true
 									$controlResult.AddMessage("`nTotal number of RGs:" + ($resourceGroups | Measure-Object).Count)


### PR DESCRIPTION
## Description
</br>
 With this capability, now policy owners will be able to whitelist resource groups by providing RG names or regular expressions under _WhitelistedResourceGroups_ in the ControlSettings.json, with which RGs can be matched, in order to exempt them from tagging compliance.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
