### PR TITLE
Adding mandatory and optional ASC default initiative policies.

### DIFF
--- a/src/AzSK/Framework/Configurations/SubscriptionSecurity/SecurityCenter.json
+++ b/src/AzSK/Framework/Configurations/SubscriptionSecurity/SecurityCenter.json
@@ -1,4 +1,4 @@
-﻿{    
+﻿{
     "Version": "3.1809.0",    
     "autoProvisioning" : {
         "id": "/subscriptions/{0}/providers/Microsoft.Security/autoProvisioningSettings/default",
@@ -31,23 +31,227 @@
             "notScopes": [],
             "parameters": {                                                              
                 "systemUpdatesMonitoringEffect": {
-                "value": "AuditIfNotExists"
+                    "value": "AuditIfNotExists"
                 },
                 "systemConfigurationsMonitoringEffect": {
-                "value": "AuditIfNotExists"
+                    "value": "AuditIfNotExists"
                 },
                 "endpointProtectionMonitoringEffect": {
-                "value": "AuditIfNotExists"
-                },           
-                "sqlAuditingMonitoringEffect": {
-                "value": "AuditIfNotExists"
+                    "value": "AuditIfNotExists"
                 },
                 "sqlEncryptionMonitoringEffect": {
-                "value": "AuditIfNotExists"
+                    "value": "AuditIfNotExists"
+                },               
+                "apiAppDisableRemoteDebuggingMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "functionAppDisableRemoteDebuggingMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "webAppDisableRemoteDebuggingMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "apiAppEnforceHttpsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "functionAppEnforceHttpsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
                 },            
-                "storageEncryptionMonitoringEffect": {
-                "value": "Audit"
-                }                     
+                "webAppEnforceHttpsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "aadAuthenticationInServiceFabricMonitoringEffect": {
+                    "value": "Audit"
+                },
+                "clusterProtectionLevelInServiceFabricMonitoringEffect": {
+                    "value": "Audit"
+                },
+                "sqlServerAdvancedDataSecurityMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "aadAuthenticationInSqlServerMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "disableUnrestrictedNetworkToStorageAccountMonitoringEffect": {
+                    "value": "Audit"
+                },            
+                "secureTransferToStorageAccountMonitoringEffect": {
+                    "value": "Audit"
+                },                 
+                "identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "identityRemoveExternalAccountWithWritePermissionsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "identityRemoveExternalAccountWithReadPermissionsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "identityRemoveDeprecatedAccountMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "classicStorageAccountsMonitoringEffect": {
+                    "value": "Audit"
+                },            
+                "classicComputeVMsMonitoringEffect": {
+                    "value": "Audit"
+                },
+                "diskEncryptionMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "vulnerabilityAssesmentMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },                 
+                "vmssOsVulnerabilitiesMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "vmssEndpointProtectionMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "vmssSystemUpdatesMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "sqlDbVulnerabilityAssesmentMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "vnetEnableDDoSProtectionMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "sqlManagedInstanceAdvancedDataSecurityMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                }
+            },
+            "description": "This policy assignment was automatically created by Azure Security Center",
+            "metadata": {
+                "assignedBy": "Security Center"
+            }
+        },
+        "id": "/subscriptions/{0}/providers/Microsoft.Authorization/policyAsssignments/SecurityCenterBuiltIn",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "SecurityCenterBuiltIn"
+    },
+    "optionalPolicySettings" : {
+        "sku": {
+        "name": "A0",
+        "tier": "Free"
+        },
+        "properties": {
+            "displayName": "ASC Default (subscription: {0})",
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+            "scope": "/subscriptions/{0}",
+            "notScopes": [],
+            "parameters": {                                                              
+                "apiAppRestrictCORSAccessMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "webAppRestrictCORSAccessMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "functionAppRestrictCORSAccessMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "diagnosticsLogsInSelectiveAppServicesMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },               
+                "encryptionOfAutomationAccountMonitoringEffect": {
+                    "value": "Audit"
+                },
+                "diagnosticsLogsInBatchAccountMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "metricAlertsInBatchAccountMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "diagnosticsLogsInDataLakeAnalyticsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "diagnosticsLogsInDataLakeStoreMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "diagnosticsLogsInEventHubMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "accessRulesInEventHubNamespaceMonitoringEffect": {
+                    "value": "Disabled"
+                },
+                "diagnosticsLogsInKeyVaultMonitoringEffect": {
+                    "value": "Disabled"
+                },
+                "diagnosticsLogsInLogicAppsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "diagnosticsLogsInSearchServiceMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "diagnosticsLogsInServiceBusMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "namespaceAuthorizationRulesInServiceBusMonitoringEffect": {
+                    "value": "Disabled"
+                },                 
+                "diagnosticsLogsInServiceFabricMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "sqlServerAuditingMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "sqlAuditingMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "diagnosticsLogsInStreamAnalyticsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "useRbacRulesMonitoringEffect": {
+                    "value": "Audit"
+                },            
+                "identityDesignateLessThanOwnersMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "identityDesignateMoreThanOneOwnerMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },                 
+                "restrictAccessToManagementPortsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "adaptiveNetworkHardeningsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "networkSecurityGroupsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "disableIPForwardingMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "diagnosticsLogsInIoTHubMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "jitNetworkAccessMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "adaptiveApplicationControlsMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },                 
+                "webApplicationFirewallMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "nextGenerationFirewallMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "sqlDbDataClassificationMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },           
+                "vulnerabilityAssessmentOnServerMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },
+                "vulnerabilityAssessmentOnManagedInstanceMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                },            
+                "restrictAccessToAppServicesMonitoringEffect": {
+                    "value": "AuditIfNotExists"
+                }
             },
             "description": "This policy assignment was automatically created by Azure Security Center",
             "metadata": {
@@ -58,4 +262,4 @@
         "type": "Microsoft.Authorization/policyAssignments",
         "name": "SecurityCenterBuiltIn"
     }
-}    
+}

--- a/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
+++ b/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
@@ -12,6 +12,7 @@ class SubscriptionCore: SVTBase
 	hidden [PSObject] $CurrentContext;
 	hidden [bool] $HasGraphAPIAccess;
 	hidden [PSObject] $MisConfiguredASCPolicies;
+	hidden [PSObject] $MisConfiguredOptionalASCPolicies;
 	hidden [SecurityCenter] $SecurityCenterInstance;
 	hidden [string[]] $SubscriptionMandatoryTags = @();
 	hidden [System.Collections.Generic.List[TelemetryRBAC]] $PIMAssignments;
@@ -38,6 +39,7 @@ class SubscriptionCore: SVTBase
 		#Compute the policies ahead to get the security Contact Phone number and email id
 		$this.SecurityCenterInstance = [SecurityCenter]::new($this.SubscriptionContext.SubscriptionId,$false);
 		$this.MisConfiguredASCPolicies = $this.SecurityCenterInstance.CheckASCCompliance();
+		$this.MisConfiguredOptionalASCPolicies = $this.SecurityCenterInstance.CheckOptionalSecurityPolicySettings();
 
 		#Fetch AzSKRGTags
 		$azskRG = [ConfigurationManager]::GetAzSKConfigData().AzSKRGName;
@@ -458,6 +460,9 @@ class SubscriptionCore: SVTBase
 		if ($this.SecurityCenterInstance)
 		{
 			#$controlResult.AddMessage([MessageData]::new("Security center policies must be configured with settings mentioned below:", $this.SecurityCenterInstance.Policy.properties));			
+
+			$this.SubscriptionContext.SubscriptionMetadata.Add("MissingOptionalASCPolicies",$this.MisConfiguredOptionalASCPolicies);
+			$this.SubscriptionContext.SubscriptionMetadata.Add("MissingMandatoryASCPolicies",$this.MisConfiguredASCPolicies);
 
 			if(($this.MisConfiguredASCPolicies | Measure-Object).Count -ne 0)
 			{
@@ -968,14 +973,8 @@ class SubscriptionCore: SVTBase
 					#Check if mandatory tags list present
 			if([Helpers]::CheckMember($this.ControlSettings,"MandatoryTags") -and ($this.ControlSettings.MandatoryTags | Measure-Object).Count -ne 0)
 			{
-				$whitelistedResourceGroupsRegex = [System.Collections.ArrayList]::new()
-				if ([Helpers]::CheckMember($this.ControlSettings,"WhitelistedResourceGroups") -and ($this.ControlSettings.WhitelistedResourceGroups | Measure-Object).Count -ne 0) 
-				{
-					$whitelistedResourceGroupsRegex = $this.ControlSettings.WhitelistedResourceGroups						
-				}
-				$whitelistedResourceGroupsRegex = (('^' + (($whitelistedResourceGroupsRegex |foreach {[regex]::escape($_)}) –join '|') + '$')) -replace '[\\]',''
-				$resourceGroups = Get-AzResourceGroup | Where-Object {$_.ResourceGroupName -inotmatch $whitelistedResourceGroupsRegex}
-				if(($resourceGroups | Measure-Object).Count -gt 0)
+					$resourceGroups = Get-AzResourceGroup
+					if(($resourceGroups | Measure-Object).Count -gt 0)
 					{
 									$rgTagStatus = $true
 									$controlResult.AddMessage("`nTotal number of RGs:" + ($resourceGroups | Measure-Object).Count)

--- a/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
+++ b/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
@@ -4,6 +4,7 @@ class SecurityCenter: AzSKRoot
 {    	
 	[PSObject] $PolicyObject = $null;
 	[PSObject] $CurrentPolicyObject = $null;
+	[bool] $PolicyAPIFail = $false;
 	[string] $Off = "Off";
 	[string] $On = "On";
 	[string] $ContactPhoneNumber;
@@ -79,6 +80,7 @@ class SecurityCenter: AzSKRoot
 				$this.CurrentPolicyObject = Get-AzPolicyAssignment -Name $policyName
 			}
 			catch {
+				$this.PolicyAPIFail = $true;
 				#eat the exception as it would throw in non availability of policy
 			}			
 		}
@@ -323,7 +325,15 @@ class SecurityCenter: AzSKRoot
 			}
 		}elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.policySettings)
         {
-            $MisConfiguredPolicies += (" Mandatory ASC Policies are misconfigured");   
+			if($this.PolicyAPIFail)
+			{
+				$MisConfiguredPolicies += ("Mandatory ASC Policies information can't be fetched due to API access failure.");
+			}
+			else
+			{
+				$MisConfiguredPolicies += ("Mandatory ASC Policies are not configured");	
+			}
+               
         }
 		
 		return $MisConfiguredPolicies;		
@@ -347,7 +357,14 @@ class SecurityCenter: AzSKRoot
 		}
 	 	}elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.optionalPolicySettings)
          {
-             $MisConfiguredOptionalPolicies += ("Optional ASC Policies are misconfigured");   
+            if($this.PolicyAPIFail)
+			{
+				$MisConfiguredOptionalPolicies += ("Optional ASC Policies information can't be fetched due to API access failure.");
+			}
+			else
+			{
+				$MisConfiguredOptionalPolicies += ("Optional ASC Policies are not configured");	
+			}
          }
 	
 	 	return $MisConfiguredOptionalPolicies;		

--- a/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
+++ b/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
@@ -24,7 +24,7 @@ class SecurityCenter: AzSKRoot
 		[SecurityCenterHelper]::RegisterResourceProvider();
 		$this.LoadPolicies(); 
 		$this.LoadCurrentPolicy();
-		#calling this function as it would fetch the current contact phone number settings
+		#calling this function as it would fetch the current contact phone number settings 
 		$this.CheckSecurityContactSettings();
 	}
 
@@ -89,7 +89,7 @@ class SecurityCenter: AzSKRoot
 		$this.PolicyObject = [ConfigurationManager]::LoadServerConfigFile("SecurityCenter.json");
 	}
 
-	[MessageData[]] SetPolicies([bool] $updateProvisioningSettings, [bool] $updatePolicies, [bool] $updateSecurityContacts)
+	[MessageData[]] SetPolicies([bool] $updateProvisioningSettings, [bool] $updatePolicies, [bool] $updateSecurityContacts, [bool] $setOptionalPolicy)
     {				
 		[MessageData[]] $messages = @();
 		$this.PublishCustomMessage("Updating SecurityCenter policies...`n" + [Constants]::SingleDashLine, [MessageType]::Warning);
@@ -104,6 +104,12 @@ class SecurityCenter: AzSKRoot
 			$this.PublishCustomMessage("Updating SecurityPolicy settings...", [MessageType]::Warning);
 			$this.SetSecurityPolicySettings();						
 			$this.PublishCustomMessage("Completed updating SecurityPolicy settings.", [MessageType]::Update);
+		}
+		if($setOptionalPolicy)
+		{
+			$this.PublishCustomMessage("Updating optional SecurityPolicy settings...", [MessageType]::Warning);
+			$this.SetSecurityOptionalPolicySettings();						
+			$this.PublishCustomMessage("Completed optional SecurityPolicy settings.", [MessageType]::Update);
 		}
 		if($updateSecurityContacts)
 		{
@@ -220,11 +226,35 @@ class SecurityCenter: AzSKRoot
 		return $messages;
 	}
 
+	[MessageData[]] SetSecurityOptionalPolicySettings()
+	{
+		[MessageData[]] $messages = @();
+		if($null -ne $this.PolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)
+		{	
+			$ResourceAppIdURI = [WebRequestHelper]::GetResourceManagerUrl()				
+			$this.UpdateOptionalPolicyObject();
+			$policySettingsUri = $ResourceAppIdURI + "subscriptions/$($this.SubscriptionContext.SubscriptionId)/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn$([SecurityCenterHelper]::ApiVersionLatest)";
+			$body = $this.PolicyObject.optionalPolicySettings | ConvertTo-Json -Depth 10
+			$body = $body.Replace("{0}",$this.SubscriptionContext.SubscriptionId) | ConvertFrom-Json;
+		  	[WebRequestHelper]::InvokeWebRequest([Microsoft.PowerShell.Commands.WebRequestMethod]::Put, $policySettingsUri, $body);
+		}
+		return $messages;
+	}
+
 	[string[]] CheckSecurityPolicySettings()
 	{
 		if($null -ne $this.PolicyObject -and $null -ne $this.PolicyObject.policySettings)
 		{	
 			return $this.ValidatePolicyObject();											
+		}
+		return $null;
+	}
+
+	[string[]] CheckOptionalSecurityPolicySettings()
+	{
+		if($null -ne $this.PolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)
+		{	
+			return $this.ValidateOptionalPolicyObject();											
 		}
 		return $null;
 	}
@@ -251,9 +281,32 @@ class SecurityCenter: AzSKRoot
 		}		
 	}	
 
+	[void] UpdateOptionalPolicyObject()
+	{
+		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)	
+		{
+			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
+			$defaultPoliciesNames = Get-Member -InputObject $this.PolicyObject.optionalPolicySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
+			$configuredPolicyObject = $this.PolicyObject.optionalPolicySettings.properties.parameters;
+			$defaultPoliciesNames | ForEach-Object {
+				$policyName = $_.Name;
+                if([Helpers]::CheckMember($currentPolicyObj,$policyName))
+                {
+                    $currentPolicyObj.$policyName.value = $configuredPolicyObject.$policyName.value
+                }else
+                {
+                    $currentPolicyObj | Add-Member -NotePropertyName $policyName -NotePropertyValue $configuredPolicyObject.$policyName
+                }				
+				
+			}
+			$this.PolicyObject.optionalPolicySettings.properties.parameters = $currentPolicyObj;
+		}		
+	}	
+
 	[string[]] ValidatePolicyObject()
 	{
 		[string[]] $MisConfiguredPolicies = @();
+
 		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.policySettings)	
 		{
 			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
@@ -264,14 +317,39 @@ class SecurityCenter: AzSKRoot
              		
 				if((-not [Helpers]::CheckMember($currentPolicyObj,$policyName)) -or ($currentPolicyObj.$policyName.value -ne $configuredPolicyObject.$policyName.value))
 				{
-					$MisConfiguredPolicies += ("Misconfigured Policy: [" + $policyName + "]");
+					$MisConfiguredPolicies += ("Misconfigured Mandatory Policy: [" + $policyName + "]");
 				}
                 
 			}
 		}elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.policySettings)
         {
-            $MisConfiguredPolicies += ("ASC Policies are misconfigured");   
+            $MisConfiguredPolicies += (" Mandatory ASC Policies are misconfigured");   
         }
+		
 		return $MisConfiguredPolicies;		
+	}	
+	[string[]] ValidateOptionalPolicyObject()
+	{
+	 	[string[]] $MisConfiguredOptionalPolicies = @();
+		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)	
+		{
+			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
+			$optionalPoliciesNames = Get-Member -InputObject $this.PolicyObject.optionalPolicySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
+			$configuredOptionalPolicyObject = $this.PolicyObject.optionalPolicySettings.properties.parameters;
+			$optionalPoliciesNames | ForEach-Object {
+				$policyName = $_.Name;		
+						
+				if((-not [Helpers]::CheckMember($currentPolicyObj,$policyName)) -or ($currentPolicyObj.$policyName.value -ne $configuredOptionalPolicyObject.$policyName.value))
+				{
+					$MisConfiguredOptionalPolicies += ("Misconfigured Optional Policy: [" + $policyName + "]");
+				}
+				
+		}
+	 	}elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.optionalPolicySettings)
+         {
+             $MisConfiguredOptionalPolicies += ("Optional ASC Policies are misconfigured");   
+         }
+	
+	 	return $MisConfiguredOptionalPolicies;		
 	}	
 }

--- a/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenterStatus.ps1
+++ b/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenterStatus.ps1
@@ -13,7 +13,7 @@ class SecurityCenterStatus: CommandBase
         Base($subscriptionId, $invocationContext)
     { }
 
-	[string] SetPolicies()
+	[string] SetPolicies([bool] $setOptionalPolicy)
     {	
 		$secCenter = [SecurityCenter]::new($this.SubscriptionContext.SubscriptionId,$this.SecurityContactEmails, $this.SecurityPhoneNumber);
 
@@ -22,7 +22,7 @@ class SecurityCenterStatus: CommandBase
 			$updatePolicies = $true;
 			$updateSecurityContacts = $true;
 			$updateProvisioningSettings = $true;
-			return $this.InvokeFunction($secCenter.SetPolicies,@($updateProvisioningSettings,$updatePolicies,$updateSecurityContacts));
+			return $this.InvokeFunction($secCenter.SetPolicies,@($updateProvisioningSettings,$updatePolicies,$updateSecurityContacts,$setOptionalPolicy));
 		}
 
 		return "";

--- a/src/AzSK/SubscriptionSecurity/SecurityCenter.ps1
+++ b/src/AzSK/SubscriptionSecurity/SecurityCenter.ps1
@@ -17,6 +17,8 @@ function Set-AzSKAzureSecurityCenterPolicies
 			Switch to specify whether to open output folder containing all security evaluation report or not.
 	.PARAMETER SecurityPhoneNumber
 			Provide a security contact international information phone number including the country code (for example, +1-425-1234567)
+	.PARAMETER OptionalPolicies
+			Switch to specify whether to set the optional ASC policies.
 
 	.LINK
 	https://aka.ms/azskossdocs 
@@ -44,7 +46,12 @@ function Set-AzSKAzureSecurityCenterPolicies
 		[switch]
         [Parameter(Mandatory = $false, HelpMessage = "Switch to specify whether to open output folder containing all security evaluation report or not.")]
 		[Alias("dnof")]
-		$DoNotOpenOutputFolder
+		$DoNotOpenOutputFolder,
+
+		[switch]
+        [Parameter(Mandatory = $false, HelpMessage = "Switch to specify whether to set the optional ASC policies.")]
+		[Alias("op")]
+		$OptionalPolicies
     )
 
 	Begin
@@ -62,7 +69,12 @@ function Set-AzSKAzureSecurityCenterPolicies
 			{
 				$secCenter.SecurityContactEmails = $SecurityContactEmails;
 				$secCenter.SecurityPhoneNumber = $SecurityPhoneNumber;
-				return $secCenter.SetPolicies();
+				$setOptionalPolicy = $false;
+
+				if ($OptionalPolicies){
+					$setOptionalPolicy = $true;
+				}
+				return $secCenter.SetPolicies($setOptionalPolicy);
 			}
 		}
 		catch 


### PR DESCRIPTION
## Description
</br>
 This PR contains the following:
1. More mandatory ASC default initiative policies will now be checked via control 'Azure_Subscription_Config_Azure_Security_Center'.
2. Many optional ASC policies will now be checked for telemetry purpose.
3. Set-AzSKAzureSecurityCenterPolicies will now have an additional switch to fix the missing/misconfigured optional policies.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
