### PR TITLE
The AppService270 control has a spelling mistake

### DIFF
--- a/src/AzSK/Framework/Configurations/ARMChecker/ARMControls.json
+++ b/src/AzSK/Framework/Configurations/ARMChecker/ARMControls.json
@@ -410,7 +410,7 @@
           "apiVersions": [ "2016-09-01" ],
           "controlId": "Azure_AppService_BCDR_Use_Multiple_Instances",
           "isEnabled": true,
-          "description": "App Service must be deplsoyed on a minimum of two instances to ensure availability",
+          "description": "App Service must be deployed on a minimum of two instances to ensure availability",
           "rationale": "App Service deployed on multiple instances ensures that the App Service remains available even if an instance is down.",
           "recommendation": "Run command 'Set-AzAppServicePlan -Name '<AppServicePlanName>' -ResourceGroupName '<RGName>' -NumberofWorkers '<NumberofInstances>''. Run 'Get-Help Set-AzAppServicePlan -full' for more help.",
           "severity": "Medium",

--- a/src/OSSConfiguration/ARMControls.json
+++ b/src/OSSConfiguration/ARMControls.json
@@ -410,7 +410,7 @@
           "apiVersions": [ "2016-09-01" ],
           "controlId": "Azure_AppService_BCDR_Use_Multiple_Instances",
           "isEnabled": true,
-          "description": "App Service must be deplsoyed on a minimum of two instances to ensure availability",
+          "description": "App Service must be deployed on a minimum of two instances to ensure availability",
           "rationale": "App Service deployed on multiple instances ensures that the App Service remains available even if an instance is down.",
           "recommendation": "Run command 'Set-AzAppServicePlan -Name '<AppServicePlanName>' -ResourceGroupName '<RGName>' -NumberofWorkers '<NumberofInstances>''. Run 'Get-Help Set-AzAppServicePlan -full' for more help.",
           "severity": "Medium",


### PR DESCRIPTION
## Description
</br>
The AppService270 control has a spelling mistake the description says:</br>
"App Service must be deplsoyed on a minimum of two instances to ensure availability"
</br>
It should say:</br>
"App Service must be deployed on a minimum of two instances to ensure availability"
</br>
Non-relevant to the pull request:</br>
The links in the Checklist below are outdated and point to the GitHub careers page.</br>

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [X] The title of the PR clearly describes the intent of the PR.
- [X] This PR does not introduce any breaking changes to the code.
