### PR TITLE
Changes for not respecting attestation once drifted and again brought back to attested state

### DIFF
--- a/src/AzSK.Framework/Abstracts/SVTBase.ps1
+++ b/src/AzSK.Framework/Abstracts/SVTBase.ps1
@@ -794,7 +794,6 @@ class SVTBase: AzSKRoot
 		$tempHasRequiredAccess = $true;
 		$controlState = @();
 		$controlStateValue = @();
-        $hasStatDriftoccured = $false
 		try
 		{
 			# Get policy compliance if org-level flag is enabled and policy is found 

--- a/src/AzSK.Framework/Models/SVT/SVTEvent.ps1
+++ b/src/AzSK.Framework/Models/SVT/SVTEvent.ps1
@@ -129,6 +129,7 @@ class StateData: MessageDataBase
 	[string] $AttestedBy =""
 	[DateTime] $AttestedDate
 	[string] $ExpiryDate =""
+	[boolean] $hasStateDrifted = $false #flag to detect attestation state drif
 	StateData()
 	{
 	}


### PR DESCRIPTION
## Description
 Changes to store state drift in storage so as to prevent respecting of attestation is control configurations are brought back to attested state of configurations.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
