### PR TITLE
Resolving the policy effect check for duplicate ASC assignments.

### DIFF
--- a/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
+++ b/src/AzSK/Framework/Core/SubscriptionSecurity/SecurityCenter.ps1
@@ -74,15 +74,15 @@ class SecurityCenter: AzSKRoot
 	{
 		if($null -ne $this.PolicyObject -and $null -ne $this.PolicyObject.policySettings)
 		{
-			$policyName = $this.PolicyObject.policySettings.name;
+			#Fetching all the ASC initiative assignments.
+			$policyDefinitionId = $this.PolicyObject.policySettings.properties.policyDefinitionId;
 
 			try {
-				$this.CurrentPolicyObject = Get-AzPolicyAssignment -Name $policyName
+				$this.CurrentPolicyObject = Get-AzPolicyAssignment -PolicyDefinitionId $policyDefinitionId
 			}
 			catch {
 				$this.PolicyAPIFail = $true;
-				#eat the exception as it would throw in non availability of policy
-			}			
+			}		
 		}
 	}
 	
@@ -216,30 +216,122 @@ class SecurityCenter: AzSKRoot
 	[MessageData[]] SetSecurityPolicySettings()
 	{
 		[MessageData[]] $messages = @();
+
 		if($null -ne $this.PolicyObject -and $null -ne $this.PolicyObject.policySettings)
 		{	
-			$ResourceAppIdURI = [WebRequestHelper]::GetResourceManagerUrl()				
+			$ResourceAppIdURI = [WebRequestHelper]::GetResourceManagerUrl()		
+			
+			$defaultPoliciesNames = Get-Member -InputObject $this.PolicyObject.policySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
+			$configuredPolicyObject = $this.PolicyObject.policySettings.properties.parameters;	
+
 			$this.UpdatePolicyObject();
+			
 			$policySettingsUri = $ResourceAppIdURI + "subscriptions/$($this.SubscriptionContext.SubscriptionId)/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn$([SecurityCenterHelper]::ApiVersionLatest)";
 			$body = $this.PolicyObject.policySettings | ConvertTo-Json -Depth 10
 			$body = $body.Replace("{0}",$this.SubscriptionContext.SubscriptionId) | ConvertFrom-Json;
 		  	[WebRequestHelper]::InvokeWebRequest([Microsoft.PowerShell.Commands.WebRequestMethod]::Put, $policySettingsUri, $body);
+
+			if($null -ne $this.CurrentPolicyObject)
+			{
+			
+				[PSObject] $defaultDisabledPoliciesNames = @(); # This will store the mandatory policies name that require 'Disabled' policy effect.
+				$defaultPoliciesNames | ForEach-Object{
+					$policyName = $_.Name;
+					if($configuredPolicyObject.$policyName.value -eq "Disabled"){
+						$defaultDisabledPoliciesNames += $policyName; 
+					}
+				}
+
+
+				$this.CurrentPolicyObject | where{
+					$currentPolicyObj = $_.Properties.parameters #For each ASC policy assignment, we will set the policies in $defaultDisabledPoliciesNames to 'Disabled' effect so that overall effect across sub is 'Disabled'.
+					$defaultDisabledPoliciesNames | where{
+						$policyName = $_;
+						if([Helpers]::CheckMember($currentPolicyObj,$policyName) -and ($currentPolicyObj.$policyName.value -ne $configuredPolicyObject.$policyName.value))
+                		{
+                    		$currentPolicyObj.$policyName.value = $configuredPolicyObject.$policyName.value
+						}
+					}
+
+					
+						$_.Properties.parameters = $currentPolicyObj;
+						$policySettingsUri = $ResourceAppIdURI + "subscriptions/$($_.SubscriptionId)/providers/Microsoft.Authorization/policyAssignments/$($_.Name)$([SecurityCenterHelper]::ApiVersionLatest)";
+
+						$body = New-Object PSObject
+						$body | Add-Member -NotePropertyName sku -NotePropertyValue $_.sku
+						$body | Add-Member -NotePropertyName id -NotePropertyValue $_.PolicyAssignmentId
+						$body | Add-Member -NotePropertyName type -NotePropertyValue "Microsoft.Authorization/policyAssignments"
+						$body | Add-Member -NotePropertyName name -NotePropertyValue $_.Name
+						$body | Add-Member -NotePropertyName properties -NotePropertyValue $_.properties
+
+						[WebRequestHelper]::InvokeWebRequest([Microsoft.PowerShell.Commands.WebRequestMethod]::Put, $policySettingsUri, $body);
+					
+
+
+				}
+			} 
 		}
+
 		return $messages;
 	}
 
 	[MessageData[]] SetSecurityOptionalPolicySettings()
 	{
 		[MessageData[]] $messages = @();
+
 		if($null -ne $this.PolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)
 		{	
-			$ResourceAppIdURI = [WebRequestHelper]::GetResourceManagerUrl()				
+			$ResourceAppIdURI = [WebRequestHelper]::GetResourceManagerUrl()		
+
+			$optionalPoliciesNames = Get-Member -InputObject $this.PolicyObject.optionalPolicySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
+			$configuredOptionalPolicyObject = $this.PolicyObject.optionalPolicySettings.properties.parameters;
+
 			$this.UpdateOptionalPolicyObject();
+			
 			$policySettingsUri = $ResourceAppIdURI + "subscriptions/$($this.SubscriptionContext.SubscriptionId)/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn$([SecurityCenterHelper]::ApiVersionLatest)";
 			$body = $this.PolicyObject.optionalPolicySettings | ConvertTo-Json -Depth 10
 			$body = $body.Replace("{0}",$this.SubscriptionContext.SubscriptionId) | ConvertFrom-Json;
 		  	[WebRequestHelper]::InvokeWebRequest([Microsoft.PowerShell.Commands.WebRequestMethod]::Put, $policySettingsUri, $body);
+
+			if($null -ne $this.CurrentPolicyObject)
+			{
+
+				[PSObject] $optionalDisabledPoliciesNames = @(); # This will store the optional policies name that require 'Disabled' policy effect.
+				$optionalPoliciesNames | ForEach-Object{
+					$policyName = $_.Name;
+					if($configuredOptionalPolicyObject.$policyName.value -eq "Disabled"){
+						$optionalDisabledPoliciesNames += $policyName; 
+					}
+				}
+
+				$this.CurrentPolicyObject | where{
+					$currentPolicyObj = $_.Properties.parameters #For each ASC policy assignment, we will set the policies in $optionalDisabledPoliciesNames to 'Disabled' effect so that overall effect across sub is 'Disabled'.
+					$optionalDisabledPoliciesNames | where{
+						$policyName = $_;
+						if([Helpers]::CheckMember($currentPolicyObj,$policyName) -and ($currentPolicyObj.$policyName.value -ne $configuredOptionalPolicyObject.$policyName.value))
+                		{
+                    		$currentPolicyObj.$policyName.value = $configuredOptionalPolicyObject.$policyName.value
+						}
+					}
+
+						$_.Properties.parameters = $currentPolicyObj;
+						$policySettingsUri = $ResourceAppIdURI + "subscriptions/$($_.SubscriptionId)/providers/Microsoft.Authorization/policyAssignments/$($_.Name)$([SecurityCenterHelper]::ApiVersionLatest)";
+
+						$body = New-Object PSObject
+						$body | Add-Member -NotePropertyName sku -NotePropertyValue $_.sku
+						$body | Add-Member -NotePropertyName id -NotePropertyValue $_.PolicyAssignmentId
+						$body | Add-Member -NotePropertyName type -NotePropertyValue "Microsoft.Authorization/policyAssignments"
+						$body | Add-Member -NotePropertyName name -NotePropertyValue $_.Name
+						$body | Add-Member -NotePropertyName properties -NotePropertyValue $_.properties
+
+						[WebRequestHelper]::InvokeWebRequest([Microsoft.PowerShell.Commands.WebRequestMethod]::Put, $policySettingsUri, $body);
+					
+
+
+				}
+			}   
 		}
+
 		return $messages;
 	}
 
@@ -265,21 +357,26 @@ class SecurityCenter: AzSKRoot
 	{
 		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.policySettings)	
 		{
-			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
-			$defaultPoliciesNames = Get-Member -InputObject $this.PolicyObject.policySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
-			$configuredPolicyObject = $this.PolicyObject.policySettings.properties.parameters;
-			$defaultPoliciesNames | ForEach-Object {
-				$policyName = $_.Name;
-                if([Helpers]::CheckMember($currentPolicyObj,$policyName))
-                {
-                    $currentPolicyObj.$policyName.value = $configuredPolicyObject.$policyName.value
-                }else
-                {
-                    $currentPolicyObj | Add-Member -NotePropertyName $policyName -NotePropertyValue $configuredPolicyObject.$policyName
-                }				
-				
+			$ASCAssignment = $this.CurrentPolicyObject | where {$_.Name -eq $this.PolicyObject.policySettings.name}
+			$ASCcount = ($ASCAssignment | Measure-Object).Count
+			if($ASCcount -eq 1)
+			{
+				$currentPolicyObj = $ASCAssignment.Properties.parameters;
+				$defaultPoliciesNames = Get-Member -InputObject $this.PolicyObject.policySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
+				$configuredPolicyObject = $this.PolicyObject.policySettings.properties.parameters;
+				$defaultPoliciesNames | ForEach-Object {
+					$policyName = $_.Name;
+					if([Helpers]::CheckMember($currentPolicyObj,$policyName))
+					{
+						$currentPolicyObj.$policyName.value = $configuredPolicyObject.$policyName.value
+					}else
+					{
+						$currentPolicyObj | Add-Member -NotePropertyName $policyName -NotePropertyValue $configuredPolicyObject.$policyName
+					}				
+					
+				}
+				$this.PolicyObject.policySettings.properties.parameters = $currentPolicyObj;
 			}
-			$this.PolicyObject.policySettings.properties.parameters = $currentPolicyObj;
 		}		
 	}	
 
@@ -287,21 +384,26 @@ class SecurityCenter: AzSKRoot
 	{
 		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)	
 		{
-			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
-			$defaultPoliciesNames = Get-Member -InputObject $this.PolicyObject.optionalPolicySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
-			$configuredPolicyObject = $this.PolicyObject.optionalPolicySettings.properties.parameters;
-			$defaultPoliciesNames | ForEach-Object {
-				$policyName = $_.Name;
-                if([Helpers]::CheckMember($currentPolicyObj,$policyName))
-                {
-                    $currentPolicyObj.$policyName.value = $configuredPolicyObject.$policyName.value
-                }else
-                {
-                    $currentPolicyObj | Add-Member -NotePropertyName $policyName -NotePropertyValue $configuredPolicyObject.$policyName
-                }				
-				
+			$ASCAssignment = $this.CurrentPolicyObject | where {$_.Name -eq $this.PolicyObject.policySettings.name}
+			$ASCcount = ($ASCAssignment | Measure-Object).Count
+			if($ASCcount -eq 1)
+			{
+				$currentPolicyObj = $ASCAssignment.Properties.parameters;
+				$optionalPoliciesNames = Get-Member -InputObject $this.PolicyObject.optionalPolicySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
+				$configuredOptionalPolicyObject = $this.PolicyObject.optionalPolicySettings.properties.parameters;
+				$optionalPoliciesNames | ForEach-Object {
+					$policyName = $_.Name;
+					if([Helpers]::CheckMember($currentPolicyObj,$policyName))
+					{
+						$currentPolicyObj.$policyName.value = $configuredOptionalPolicyObject.$policyName.value
+					}else
+					{
+						$currentPolicyObj | Add-Member -NotePropertyName $policyName -NotePropertyValue $configuredOptionalPolicyObject.$policyName
+					}				
+					
+				}
+				$this.PolicyObject.optionalPolicySettings.properties.parameters = $currentPolicyObj;
 			}
-			$this.PolicyObject.optionalPolicySettings.properties.parameters = $currentPolicyObj;
 		}		
 	}	
 
@@ -309,21 +411,52 @@ class SecurityCenter: AzSKRoot
 	{
 		[string[]] $MisConfiguredPolicies = @();
 
-		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.policySettings)	
+		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.policySettings)
 		{
-			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
+			$assignCount = ($this.CurrentPolicyObject | Measure-Object).Count # Total no. of ASC initiative assignments (duplicates).
 			$defaultPoliciesNames = Get-Member -InputObject $this.PolicyObject.policySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
 			$configuredPolicyObject = $this.PolicyObject.policySettings.properties.parameters;
+
 			$defaultPoliciesNames | ForEach-Object {
 				$policyName = $_.Name;		
-             		
-				if((-not [Helpers]::CheckMember($currentPolicyObj,$policyName)) -or ($currentPolicyObj.$policyName.value -ne $configuredPolicyObject.$policyName.value))
+                $counter = 0; 					# count of misconfigured instances of the policy under iteration.
+				$polNotFoundCounter = 0;		# count of assignments in which the policy under iteration is absent.
+
+				if($configuredPolicyObject.$policyName.value -ne "Disabled")				# If the desired effect of a policy is not "Disabled" i.e. "Audit/AuditIfNotExists", then atleast one initiative assignment should have the correct effect so that the policy is correctly configured on the sub.
 				{
-					$MisConfiguredPolicies += ("Misconfigured Mandatory Policy: [" + $policyName + "]");
+					$enabledAssignments = $this.CurrentPolicyObject | where{[Helpers]::CheckMember($_.Properties.parameters,$policyName) -and $_.Properties.parameters.$policyName.value -eq $configuredPolicyObject.$policyName.value}	
+					$counter = ($enabledAssignments | Measure-Object).Count
+
+					if($counter -eq 0) # If policy is absent/misconfigured in all the assignments, then the overall effect of the policy is opposite of what is required (Here "Audit/AuditIfNotExists").
+					{
+						$MisConfiguredPolicies += ("Misconfigured Mandatory Policy: [" + $policyName + "]");
+					}
+
 				}
-                
+				elseif($configuredPolicyObject.$policyName.value -eq "Disabled")           # If the desired effect of a policy is "Disabled", then no initiative assignments should have a stronger effect (Audit / AuditIfNotExists) for the policy under consideration.
+				{
+		
+					$enabledAssignments = $this.CurrentPolicyObject | where{[Helpers]::CheckMember($_.Properties.parameters,$policyName) -and $_.Properties.parameters.$policyName.value -ne $configuredPolicyObject.$policyName.value}	
+					$counter = ($enabledAssignments | Measure-Object).Count
+
+					if($counter -gt 0)		# This means in atleast one assignment, the effect is not 'Disabled', i.e it is "Audit/AuditIfNotExists" making the stronger effect win.
+					{
+						$MisConfiguredPolicies += ("Misconfigured Mandatory Policy: [" + $policyName + "]");
+					}
+					else					# This means either the policy is absent in all the assignments or it is configured correctly wherever present.
+					{
+						$absentAssignments = $this.CurrentPolicyObject | where{-not [Helpers]::CheckMember($_.Properties.parameters,$policyName)}
+						$polNotFoundCounter = ($absentAssignments | Measure-Object).Count
+						if($polNotFoundCounter -eq $assignCount)		# This means policy is absent across all assignments meaning it is not in effect on the sub.
+						{
+							$MisConfiguredPolicies += ("Misconfigured Mandatory Policy: [" + $policyName + "]");
+						}
+					}
+				}
 			}
-		}elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.policySettings)
+
+		}
+		elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.policySettings)
         {
 			if($this.PolicyAPIFail)
 			{
@@ -341,31 +474,67 @@ class SecurityCenter: AzSKRoot
 	[string[]] ValidateOptionalPolicyObject()
 	{
 	 	[string[]] $MisConfiguredOptionalPolicies = @();
-		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)	
+
+		if($null -ne $this.CurrentPolicyObject -and $null -ne $this.PolicyObject.optionalPolicySettings)
 		{
-			$currentPolicyObj = $this.CurrentPolicyObject.Properties.parameters;
+			$assignCount = ($this.CurrentPolicyObject | Measure-Object).Count 				# Total no. of ASC initiative assignments (duplicates).
 			$optionalPoliciesNames = Get-Member -InputObject $this.PolicyObject.optionalPolicySettings.properties.parameters -MemberType NoteProperty | Select-Object Name
 			$configuredOptionalPolicyObject = $this.PolicyObject.optionalPolicySettings.properties.parameters;
+
 			$optionalPoliciesNames | ForEach-Object {
 				$policyName = $_.Name;		
-						
-				if((-not [Helpers]::CheckMember($currentPolicyObj,$policyName)) -or ($currentPolicyObj.$policyName.value -ne $configuredOptionalPolicyObject.$policyName.value))
+                $counter = 0;							# count of misconfigured instances of the policy under iteration.
+				$polNotFoundCounter = 0;				# count of assignments in which the policy under iteration is absent.
+
+
+				if($configuredOptionalPolicyObject.$policyName.value -ne "Disabled")		# If the desired effect of a policy is not "Disabled" i.e. "Audit/AuditIfNotExists", then atleast one initiative assignment should have the correct effect so that the policy is correctly configured on the sub.
 				{
-					$MisConfiguredOptionalPolicies += ("Misconfigured Optional Policy: [" + $policyName + "]");
+
+					$enabledAssignments = $this.CurrentPolicyObject | where{[Helpers]::CheckMember($_.Properties.parameters,$policyName) -and $_.Properties.parameters.$policyName.value -eq $configuredOptionalPolicyObject.$policyName.value}	
+					$counter = ($enabledAssignments | Measure-Object).Count
+
+					if($counter -eq 0)			# If policy is absent/misconfigured in all the assignments, then the overall effect of the policy is opposite of what is required (Here "Audit/AuditIfNotExists").
+					{
+						$MisConfiguredOptionalPolicies += ("Misconfigured Optional Policy: [" + $policyName + "]");
+					}
+
 				}
-				
+				elseif($configuredOptionalPolicyObject.$policyName.value -eq "Disabled")    # If the desired effect of a policy is "Disabled", then no initiative assignments should have a stronger effect (Audit / AuditIfNotExists) for the policy under consideration.
+				{
+	
+					$enabledAssignments = $this.CurrentPolicyObject | where{[Helpers]::CheckMember($_.Properties.parameters,$policyName) -and $_.Properties.parameters.$policyName.value -ne $configuredOptionalPolicyObject.$policyName.value}	
+					$counter = ($enabledAssignments | Measure-Object).Count
+
+					if($counter -gt 0)				# This means in atleast one assignment, the effect is not 'Disabled', i.e it is "Audit/AuditIfNotExists" making the stronger effect win.
+					{
+						$MisConfiguredOptionalPolicies += ("Misconfigured Optional Policy: [" + $policyName + "]");
+					}
+					else							# This means either the policy is absent in all the assignments or it is configured correctly wherever present.
+					{
+						$absentAssignments = $this.CurrentPolicyObject | where{-not [Helpers]::CheckMember($_.Properties.parameters,$policyName)}
+						$polNotFoundCounter = ($absentAssignments | Measure-Object).Count
+
+						if($polNotFoundCounter -eq $assignCount)		# This means policy is absent across all assignments meaning it is not in effect on the sub.
+						{
+							$MisConfiguredOptionalPolicies += ("Misconfigured Optional Policy: [" + $policyName + "]");
+						}
+					}
+				}
+			}
+
 		}
-	 	}elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.optionalPolicySettings)
-         {
-            if($this.PolicyAPIFail)
+		elseif($null -eq $this.CurrentPolicyObject -and  $null -ne $this.PolicyObject.optionalPolicySettings)
+        {
+			if($this.PolicyAPIFail)
 			{
-				$MisConfiguredOptionalPolicies += ("Optional ASC Policies information can't be fetched due to API access failure.");
+				$MisConfiguredOptionalPolicies += ("Optional ASC Policies information can't be fetched beacuse either mandatory ASC policies are not configured or due to API access failure.");
 			}
 			else
 			{
 				$MisConfiguredOptionalPolicies += ("Optional ASC Policies are not configured");	
 			}
-         }
+               
+        }
 	
 	 	return $MisConfiguredOptionalPolicies;		
 	}	

--- a/src/AzSK/SubscriptionSecurity/SecurityCenter.ps1
+++ b/src/AzSK/SubscriptionSecurity/SecurityCenter.ps1
@@ -17,7 +17,7 @@ function Set-AzSKAzureSecurityCenterPolicies
 			Switch to specify whether to open output folder containing all security evaluation report or not.
 	.PARAMETER SecurityPhoneNumber
 			Provide a security contact international information phone number including the country code (for example, +1-425-1234567)
-	.PARAMETER OptionalPolicies
+	.PARAMETER EnableOptionalPolicies
 			Switch to specify whether to set the optional ASC policies.
 
 	.LINK
@@ -50,8 +50,8 @@ function Set-AzSKAzureSecurityCenterPolicies
 
 		[switch]
         [Parameter(Mandatory = $false, HelpMessage = "Switch to specify whether to set the optional ASC policies.")]
-		[Alias("op")]
-		$OptionalPolicies
+		[Alias("eop","OptionalPolicies")]
+		$EnableOptionalPolicies
     )
 
 	Begin
@@ -71,7 +71,7 @@ function Set-AzSKAzureSecurityCenterPolicies
 				$secCenter.SecurityPhoneNumber = $SecurityPhoneNumber;
 				$setOptionalPolicy = $false;
 
-				if ($OptionalPolicies){
+				if ($EnableOptionalPolicies){
 					$setOptionalPolicy = $true;
 				}
 				return $secCenter.SetPolicies($setOptionalPolicy);


### PR DESCRIPTION
## Description
</br>
This PR contains the following changes:

1. Set-AzSKAzureSecurityCenterPolicies paramater name "OptionalPolicies" has been renamed to "EnableOptionalPolicies" - although the older name will still be prevalent as alias.

2. In case of duplicate ASC default initiatives, polices with stronger effect ultimately win across the scope (in this case, the scope is subscription.). Before we were checking for policy effect only across ASC default initiative (maintained by AzSK). So in case where we need a policy X effect to be 'Disabled' across the subscription, we need to ensure it is 'disabled' across all the ASC assignments. Here we check for the effect across all assignments (GET scenario).

3. For SET scenario, we will be updating 'ASC default initiative' (maintained by AzSK) as per SecurityCenter.json. For other duplicate assignments, we will be disabling only those policies which require 'Disabled' effect to ensure overall 'Disabled' effect across sub.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
