### PR TITLE
Fixed anon authN storage control in fileshare type

### DIFF
--- a/src/AzSK/Framework/Configurations/SVT/Services/Storage.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/Storage.json
@@ -22,7 +22,8 @@
          "GeneralPurposeStorage",
          "BlobStorage",
          "HNSDisabled",
-         "ResourceLocked"
+         "ResourceLocked",
+         "PremiumFileShareNotSupported"
       ],
       "Enabled": true,
       "FixControl": {

--- a/src/AzSK/Framework/Configurations/SVT/Services/Storage.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/Storage.json
@@ -22,8 +22,7 @@
          "GeneralPurposeStorage",
          "BlobStorage",
          "HNSDisabled",
-         "ResourceLocked",
-         "PremiumFileShareNotSupported"
+         "ResourceLocked"
       ],
       "Enabled": true,
       "FixControl": {
@@ -98,7 +97,8 @@
          "StandardSku",
          "PremiumSku",
         "GeneralPurposeStorage",
-        "BlobStorage"
+        "BlobStorage",
+        "PremiumFileShareStorage"
       ],
       "PolicyDefinitionGuid":"404c3081-a854-4457-ae30-26a93ef643f9",
       "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/404c3081-a854-4457-ae30-26a93ef643f9",

--- a/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
@@ -72,6 +72,13 @@ class Storage: SVTBase
 				 }
 			}
 		}
+
+		#Disabling the control 'Azure_Storage_AuthN_Dont_Allow_Anonymous' for FileShare type available in Premium storage account as blobs and containers are not supported in it.
+		if([Helpers]::CheckMember($this.ResourceObject, "Kind") -and ($this.ResourceObject.Kind -eq "FileStorage"))
+		{
+			$result = $result | Where-Object {$_.Tags -notcontains "PremiumFileShareNotSupported"}
+		}
+
 		$resource = Get-AzResource -ResourceId $this.ResourceContext.ResourceId;
 		#Disabling the control 'Azure_Storage_AuthN_Dont_Allow_Anonymous' for Data Lake Storage Gen2 resources with hierarchical namespace accounts enabled as blob storage is not currently supported.
 

--- a/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/Storage.ps1
@@ -76,7 +76,7 @@ class Storage: SVTBase
 		#Disabling the control 'Azure_Storage_AuthN_Dont_Allow_Anonymous' for FileShare type available in Premium storage account as blobs and containers are not supported in it.
 		if([Helpers]::CheckMember($this.ResourceObject, "Kind") -and ($this.ResourceObject.Kind -eq "FileStorage"))
 		{
-			$result = $result | Where-Object {$_.Tags -notcontains "PremiumFileShareNotSupported"}
+			$result = $result | Where-Object {$_.Tags -contains "PremiumFileShareStorage"}
 		}
 
 		$resource = Get-AzResource -ResourceId $this.ResourceContext.ResourceId;


### PR DESCRIPTION
## Description
</br>
Disabling the control 'Azure_Storage_AuthN_Dont_Allow_Anonymous' for FileShare type available in Premium storage account as blobs and containers are not supported in it, which renders API inaccessible causing control to error out.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
