### PR TITLE
assessmentKey comparison for ASC VM Controls

### DIFF
--- a/src/AzSK/Framework/Configurations/FeatureFlighting.json
+++ b/src/AzSK/Framework/Configurations/FeatureFlighting.json
@@ -54,6 +54,15 @@
       "DisabledForSubs": [],      
       "UnderPreview" : false,
       "IsEnabled": false
+    },
+    {
+      "Name": "EnableASCPolicyOnVMCheckUsingPolicyAssessmentKey",
+      "Description": "",
+      "Sources": ["*"],
+      "EnabledForSubs": [],
+      "DisabledForSubs": [],
+      "UnderPreview": false,
+      "IsEnabled": true
     }
   ]
 }

--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -93,10 +93,15 @@
     "ASCPolicies": {
       "PolicyAssignment": {
         "EndpointProtection": "Install endpoint protection solution on your machines",
+        "EndpointProtectionAssessmentKey": "83f577bd-a1b6-b7e1-0891-12ca19d1e6df",
         "DiskEncryption": "Apply Disk Encryption on your virtual machines",
+        "DiskEncryptionAssessmentKey": "d57a4221-a804-52ca-3dea-768284f06bb7",
         "VulnerabilityScan": "Remediate vulnerabilities in security configuration on your machines",
+        "VulnerabilityScanAssessmentKey": "181ac480-f7c4-544b-9865-11b8ffe87f47",
         "OSUpdates": "Install system updates on your machines",
-        "MonitoringAgent": "Install monitoring agent on your machines"
+        "OSUpdatesAssessmentKey": "4ab6e3c5-74dd-8b35-9ab9-f61b30875b27",
+        "MonitoringAgent": "Install monitoring agent on your machines",
+        "MonitoringAgentAssessmentKey": "d1db3318-01ff-16de-29eb-28b344515626"
       },
       "ResourceDetailsKeys": {
         "WorkspaceId": "Reporting workspace customer id"

--- a/src/AzSK/Framework/Core/SVT/Services/VirtualMachine.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/VirtualMachine.ps1
@@ -321,7 +321,16 @@ class VirtualMachine: SVTBase
 		#Do not check for deallocated status for the VM and directly show the status from ASC
 		if($null -ne $this.ASCSettings -and [Helpers]::CheckMember($this.ASCSettings, "properties.policyAssessments"))
 		{
-			$antimalwareSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.EndpointProtection};
+			$antimalwareSetting = $null
+			if([FeatureFlightingManager]::GetFeatureStatus("EnableASCPolicyOnVMCheckUsingPolicyAssessmentKey",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+			{
+				$antimalwareSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.assessmentKey -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.EndpointProtectionAssessmentKey};
+			}
+			else 
+			{
+				$antimalwareSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.EndpointProtection};
+			}
+
 			if($null -ne $antimalwareSetting)
 			{
 				$controlResult.AddMessage("VM endpoint protection details:", $antimalwareSetting);
@@ -610,7 +619,16 @@ class VirtualMachine: SVTBase
 
 		if($null -ne $this.ASCSettings -and [Helpers]::CheckMember($this.ASCSettings, "properties.policyAssessments"))
 		{
-			$adeSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.DiskEncryption};
+			$adeSetting = $null
+			if([FeatureFlightingManager]::GetFeatureStatus("EnableASCPolicyOnVMCheckUsingPolicyAssessmentKey",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+			{
+				$adeSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.assessmentKey -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.DiskEncryptionAssessmentKey};
+			}
+			else 
+			{
+				$adeSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.DiskEncryption};
+			}
+
 			if($null -ne $adeSetting)
 			{
 				if($adeSetting.assessmentResult -eq 'Healthy')
@@ -675,7 +693,16 @@ class VirtualMachine: SVTBase
 
 		if($null -ne $this.ASCSettings -and [Helpers]::CheckMember($this.ASCSettings, "properties.policyAssessments"))
 		{
-			$vulnSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.VulnerabilityScan};
+			$vulnSetting = $null
+			if([FeatureFlightingManager]::GetFeatureStatus("EnableASCPolicyOnVMCheckUsingPolicyAssessmentKey",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+			{
+				$vulnSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.assessmentKey -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.VulnerabilityScanAssessmentKey};
+			}
+			else 
+			{
+				$vulnSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.VulnerabilityScan};
+			}
+
 			if($null -ne $vulnSetting)
 			{
 				if($vulnSetting.assessmentResult -eq 'Healthy')
@@ -718,7 +745,16 @@ class VirtualMachine: SVTBase
 
 				if($null -ne $this.ASCSettings -and [Helpers]::CheckMember($this.ASCSettings, "properties.policyAssessments"))
 				{
-					$patchSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.OSUpdates};
+					$patchSetting = $null
+					if([FeatureFlightingManager]::GetFeatureStatus("EnableASCPolicyOnVMCheckUsingPolicyAssessmentKey",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+					{
+						$patchSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.assessmentKey -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.OSUpdatesAssessmentKey};
+					}
+					else 
+					{
+						$patchSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.OSUpdates};
+					}
+
 					if($null -ne $patchSetting)
 					{
 						$ascPatchStatus = $patchSetting.assessmentResult;
@@ -810,7 +846,16 @@ class VirtualMachine: SVTBase
 
 			if($null -ne $this.ASCSettings -and [Helpers]::CheckMember($this.ASCSettings, "properties.policyAssessments"))
 			{
-				$vulnSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.VulnerabilityScan};
+				$vulnSetting = $null
+				if([FeatureFlightingManager]::GetFeatureStatus("EnableASCPolicyOnVMCheckUsingPolicyAssessmentKey",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+				{
+					$vulnSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.assessmentKey -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.VulnerabilityScanAssessmentKey};
+				}
+				else 
+				{
+					$vulnSetting = $this.ASCSettings.properties.policyAssessments | Where-Object {$_.policyName -eq $this.ControlSettings.VirtualMachine.ASCPolicies.PolicyAssignment.VulnerabilityScan};
+				}
+
 				if($null -ne $vulnSetting)
 				{
 					$vulnStatus = $vulnSetting.assessmentResult;


### PR DESCRIPTION
## Description
</br>
 Policy names keep changing in ASC. So instead of comparison using names, now we will compare using assessmentKey which is like the policy ID for each ASC Policy.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
