### PR TITLE
Users/khushboo/gca summary fix

### DIFF
--- a/src/AzSK/Framework/Core/ContinuousAssurance/CAAutomation.ps1
+++ b/src/AzSK/Framework/Core/ContinuousAssurance/CAAutomation.ps1
@@ -1347,8 +1347,8 @@ class CCAutomation: CommandBase
 		$altLAWSDetails = $this.GetAltLAWSId()
 
 		#Start: Code to be deleted when OMS variables will be completely removed
-		$omsWSDetails = $null
-		$altOMSWSDetails = $null
+		$omsWSDetails = $this.GetOMSWorkspaceId()
+		$altOMSWSDetails = $this.GetAltOMSWorkspaceId()
 		#End: Code to be deleted when OMS variables will be completely removed
 
 		$webhookUrl = $this.GetWebhookURL()
@@ -1383,14 +1383,21 @@ class CCAutomation: CommandBase
 			$caSummaryTable.Item("AltLAWSId") = $altLAWSDetails.Value
 		}
 
-		#Start: Code to be deleted when OMS variables will be completely removed
+		#Start: Code to be deleted when OMS variables will be completely removed		
 		if($omsWSDetails)
 		{
 			$caSummaryTable.Item("OMSWorkspaceId") = $omsWSDetails.Value
+            if($altOMSWSDetails)
+		    {
+			    $caSummaryTable.Item("AltOMSWorkspaceId") = $altOMSWSDetails.Value
+		    }
 		}
-		if($altOMSWSDetails)
+		#If OMS details are not present - it means it is a fresh CA install post v3.14.0,
+		#meaning the automation account will not have OMS* variables - therefore removing them from the CA summary.
+		else
 		{
-			$caSummaryTable.Item("AltOMSWorkspaceId") = $altOMSWSDetails.Value
+			$caSummaryTable.Remove("OMSWorkspaceId")
+			$caSummaryTable.Remove("AltOMSWorkspaceId")
 		}
 		#End: Code to be deleted when OMS variables will be completely removed
 


### PR DESCRIPTION
## Description
</br>
 In case of a fresh CA install (v3.14.0) or later, old OMS* variables won't be added to the automation account.
Fixed the bug where they were still being shown in the GCA summary.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
