### PR TITLE
fix for gss erroring out in CA if no resource found in the sub.

### DIFF
--- a/src/AzSK.Framework/Listeners/RemoteReports/RemoteReportsListener.ps1
+++ b/src/AzSK.Framework/Listeners/RemoteReports/RemoteReportsListener.ps1
@@ -46,7 +46,7 @@ class RemoteReportsListener: ListenerBase {
 				$resources.ResourceGroups = [System.Collections.ArrayList]::new()
 				$supportedResourceTypes = [SVTMapping]::GetSupportedResourceMap()
 				# # Not considering nested resources to reduce complexity
-				$filteredResources = [ResourceInventory]::FilteredResources | Where-Object { $supportedResourceTypes.ContainsKey($_.ResourceType.ToLower()) }
+				$filteredResources = [ResourceInventory]::FilteredResources
 				$grouped = $filteredResources | Group-Object {$_.ResourceGroupName} | Select-Object Name, Group				
 				foreach($group in $grouped){
 					$resourceGroup = "" | Select-Object Name, Resources

--- a/src/AzSK.Framework/Models/Common/ResourceInventory.ps1
+++ b/src/AzSK.Framework/Models/Common/ResourceInventory.ps1
@@ -11,7 +11,14 @@ class ResourceInventory
             [ResourceInventory]::RawResources = Get-AzResource
             $supportedResourceTypes = [SVTMapping]::GetSupportedResourceMap()
             # Not considering nested resources to reduce complexity
-            [ResourceInventory]::FilteredResources = [ResourceInventory]::RawResources | Where-Object { $supportedResourceTypes.ContainsKey($_.ResourceType.ToLower()) }        
+            if(-not [string]::IsNullOrWhiteSpace([ResourceInventory]::RawResources))
+            {
+                [ResourceInventory]::FilteredResources = [ResourceInventory]::RawResources | Where-Object { $supportedResourceTypes.ContainsKey($_.ResourceType.ToLower()) }        
+            }
+            else 
+            {
+                [ResourceInventory]::FilteredResources = $null;
+            }
         }                      
     }
 


### PR DESCRIPTION
## Description
</br>
 If no resource is present in the subscription, GSS errors out in CA mode.
Added a null-check for resource count in the sub. 

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
