### PR TITLE
bug fix: AttestationInfo unable to fetch attestation data and GACS

### DIFF
--- a/src/AzSK.Framework/Abstracts/SVTCommandBase.ps1
+++ b/src/AzSK.Framework/Abstracts/SVTCommandBase.ps1
@@ -157,6 +157,7 @@ class SVTCommandBase: SVTCommandBaseExt {
 		}
 		
         # ToDo: Utilize exiting functions
+        $this.InitializeControlState();
         $svtObject.ControlStateExt = $this.ControlStateExt;
     }
 


### PR DESCRIPTION
## Description
Fix for GAI -AttestationInfo  and GACS 'You cannot call a method on a null-valued expression.' error

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
