### PR TITLE
VM ASC metadata capture control and resourcetype control for sending metadata

### DIFF
--- a/src/AzSK.Framework/Abstracts/SVTBase.ps1
+++ b/src/AzSK.Framework/Abstracts/SVTBase.ps1
@@ -1415,14 +1415,27 @@ class SVTBase: AzSKRoot
 
 	hidden AddResourceMetadata([PSObject] $metadataObj)
 	{
-
 		[hashtable] $resourceMetadata = New-Object -TypeName Hashtable;
-		$metadataObj.psobject.properties |
-			ForEach-Object {
-				$resourceMetadata.Add($_.name, $_.value)
-			}
+			$metadataObj.psobject.properties |
+				ForEach-Object {
+					$resourceMetadata.Add($_.name, $_.value)
+				}
 
-		$this.ResourceContext.ResourceMetadata = $resourceMetadata
+		if([Helpers]::CheckMember($this.ControlSettings, 'AllowedResourceTypesForMetadataCapture') )
+		{
+			if( $this.ResourceContext.ResourceTypeName -in $this.ControlSettings.AllowedResourceTypesForMetadataCapture)
+			{
+				$this.ResourceContext.ResourceMetadata = $resourceMetadata
+			}
+			else
+			{
+				$this.ResourceContext.ResourceMetadata = $null
+			}
+		}
+		else 
+		{
+			$this.ResourceContext.ResourceMetadata = $resourceMetadata
+		}
 
 	}
 

--- a/src/AzSK/Framework/Configurations/FeatureFlighting.json
+++ b/src/AzSK/Framework/Configurations/FeatureFlighting.json
@@ -63,6 +63,15 @@
       "DisabledForSubs": [],
       "UnderPreview": false,
       "IsEnabled": true
+    },
+    {
+      "Name": "EnableVMASCMetadataCapture",
+      "Description": "",
+      "Sources": ["*"],
+      "EnabledForSubs": [],
+      "DisabledForSubs": [],
+      "UnderPreview": false,
+      "IsEnabled": false
     }
   ]
 }

--- a/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK/Framework/Configurations/SVT/ControlSettings.json
@@ -323,6 +323,7 @@
     "WebhookValidityInDays": 60,
     "variablesToSkip": ["AppResourceGroupNames", "ReportsStorageAccountName", "UpdateToLatestAzSKVersion", "OMSSharedKey", "OMSWorkspaceId", "AltOMSWorkspaceId", "AltOMSSharedKey", "LAWSId", "LAWSSharedKey", "AltLAWSId", "AltLAWSSharedKey", "WebhookAuthZHeaderName", "WebhookUrl"]
   },
+  "AllowedResourceTypesForMetadataCapture":["AppService", "VirtualMachine","DataFactory","DataFactoryV2"],
   "BaselineControls": {
     "ResourceTypeControlIdMappingList": [
 

--- a/src/AzSK/Framework/Configurations/SVT/Services/AppService.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/AppService.json
@@ -609,8 +609,7 @@
           "DP",
           "OwnerAccess",
           "FunctionApp",
-          "Windows",
-          "Linux"
+          "Windows"
         ],
        "Enabled": true
       },

--- a/src/AzSK/Framework/Core/SVT/Services/VirtualMachine.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/VirtualMachine.ps1
@@ -20,7 +20,10 @@ class VirtualMachine: SVTBase
 		$this.GetVMDetails();
 		$metadata= [PSObject]::new();
 		$metadata| Add-Member -Name VMDetails -Value $this.VMDetails -MemberType NoteProperty;
-		$metadata| Add-Member -Name VMASCDetails -Value $this.ASCSettings -MemberType NoteProperty;				
+		if([FeatureFlightingManager]::GetFeatureStatus("EnableVMASCMetadataCapture",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+		{
+			$metadata| Add-Member -Name VMASCDetails -Value $this.ASCSettings -MemberType NoteProperty;
+		}				
 		$this.AddResourceMetadata($metadata);	
     }
     
@@ -31,7 +34,10 @@ class VirtualMachine: SVTBase
 		$this.GetVMDetails();
 		$metadata= [PSObject]::new();
 		$metadata| Add-Member -Name VMDetails -Value $this.VMDetails -MemberType NoteProperty;
-		$metadata| Add-Member -Name VMASCDetails -Value $this.ASCSettings -MemberType NoteProperty;				
+		if([FeatureFlightingManager]::GetFeatureStatus("EnableVMASCMetadataCapture",$($this.SubscriptionContext.SubscriptionId)) -eq $true)
+		{
+			$metadata| Add-Member -Name VMASCDetails -Value $this.ASCSettings -MemberType NoteProperty;
+		}
 		$this.AddResourceMetadata($metadata);		
 		
 		#OS type must always be present in configuration setting file


### PR DESCRIPTION
## Description
The changes are:
1) Added feature flight control to enable/disable sending of VM's ASC settings in metadata.
2) Added a property in control settings file to enable sending of resource metadata to API for allowed resource types


## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
