### PR TITLE
ARM control fix emailAddresses in the securityAlertPolicies use itemCount instead of string dataType

### DIFF
--- a/src/AzSK/Framework/Configurations/ARMChecker/ARMControls.json
+++ b/src/AzSK/Framework/Configurations/ARMChecker/ARMControls.json
@@ -339,9 +339,10 @@
           "recommendation": "",
           "severity": "High",
           "jsonPath": [ "$.properties.emailAddresses" ],
-          "matchType": "StringWhitespace",
+          "matchType": "ItemCount",
           "data": {
-            "value": false
+            "type": "GreaterThanOrEqual",
+            "value": 1
           }
         },
         {

--- a/src/AzSK/Framework/Core/SVT/Services/SQLDatabase.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/SQLDatabase.ps1
@@ -91,7 +91,7 @@ class SQLDatabase: AzSVTBase
 
 		if($null -ne $serverAudit){
 				$isCompliant = (($serverAudit.BlobStorageTargetState -eq [AuditStateType]::Enabled) `
-                               -and ($serverAudit.RetentionInDays -eq $this.ControlSettings.SqlServer.AuditRetentionPeriod_Min -or $serverAudit.RetentionInDays -eq $this.ControlSettings.SqlServer.AuditRetentionPeriod_Forever))
+                               -and ($serverAudit.RetentionInDays -ge $this.ControlSettings.SqlServer.AuditRetentionPeriod_Min -or $serverAudit.RetentionInDays -eq $this.ControlSettings.SqlServer.AuditRetentionPeriod_Forever))
 
 				if ($isCompliant){
 				   		$controlResult.VerificationResult = [VerificationResult]::Passed


### PR DESCRIPTION
## Description
</br>
Based on the documentation below :
https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2017-03-01-preview/servers/securityalertpolicies
EmailAddresses must be an array instead of a string element 

The API 2015-05-01-preview cannot be used because the emailAccountAdmins was a string "enabled" / "disabled" instead of a boolean (as validated in the ARMControlChecker)

## Checklist
- [X] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [X] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [X] The title of the PR clearly describes the intent of the PR.
- [x] This PR does not introduce any breaking changes to the code. 
