### PR TITLE
Changes to remove check for CA SPN formatting in central mode

### DIFF
--- a/src/AzSK/Framework/Configurations/FeatureFlighting.json
+++ b/src/AzSK/Framework/Configurations/FeatureFlighting.json
@@ -117,6 +117,15 @@
       "DisabledForSubs": [],
       "UnderPreview": false,
       "IsEnabled": true
+    },
+    {
+      "Name": "RemoveCheckForSPNNameFormat",
+      "Description": "",
+      "Sources": ["*"],
+      "EnabledForSubs": [],
+      "DisabledForSubs": [],
+      "UnderPreview": false,
+      "IsEnabled": true
     }
   ]
 }

--- a/src/AzSK/Framework/Core/ContinuousAssurance/CAAutomation.ps1
+++ b/src/AzSK/Framework/Core/ContinuousAssurance/CAAutomation.ps1
@@ -656,10 +656,18 @@ class CCAutomation: AzCommandBase
 						$ADApp = Get-AzADApplication -ApplicationId $existingAppId -ErrorAction SilentlyContinue
 						if($this.IsCentralScanModeOn)
 						{
-							if(-not ($null -ne $ADApp -and $ADApp.DisplayName -like "$($this.AzSKCentralSPNFormatString)*"))
+							if(($null -ne $ADApp))
 							{
-								#Null out the ADApp if it is in central scan mode mode and the spn is not in central format
-								$ADApp = $null
+                                # if RemoveCheckForSPNNameFormat feature flag is enabled, do not check the SP name format thus '-not'
+                                # to enable name format check disable the feature flag 
+								if(-not ([FeatureFlightingManager]::GetFeatureStatus("RemoveCheckForSPNNameFormat","*")))
+								{
+									#Null out the ADApp if it is in central scan mode mode and the spn is not in central format
+									if(-not ($ADApp.DisplayName -like "$($this.AzSKCentralSPNFormatString)*"))
+									{
+										$ADApp = $null
+									}
+								}
 							}
 						}
 						$ServicePrincipal = Get-AzADServicePrincipal -ServicePrincipalName $existingAppId -ErrorAction SilentlyContinue

--- a/src/AzSK/PIM/PIM.ps1
+++ b/src/AzSK/PIM/PIM.ps1
@@ -129,9 +129,8 @@ function Set-AzSKPIMConfiguration {
 
         [Parameter(Mandatory = $true, ParameterSetName = "Assign")]
         [Parameter(Mandatory = $true, ParameterSetName = "ExtendExpiringAssignmentForUsers")]
-        [Alias("GroupName")]
         [ValidateNotNullOrEmpty()]
-	    [Alias("pn")]
+	    [Alias("pn","PrincipalName","GroupName")]
         [string[]]
         $PrincipalNames,
 


### PR DESCRIPTION
## Description
1)Check for CA SPN name expression removed to by pass force certificate creation in case an AD App with name not according to AzSK SP naming convention is used in automation account run as connection
2)Added previous parameter name  for PrincipalNames in alias
## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
