### PR TITLE
if aks version is missing set control to passed (latest)

### DIFF
--- a/src/AzSK/Framework/Core/SVT/Services/KubernetesService.ps1
+++ b/src/AzSK/Framework/Core/SVT/Services/KubernetesService.ps1
@@ -123,6 +123,9 @@ class KubernetesService: AzSVTBase
                 if($resourceKubernetesVersion -eq [System.Version] $_){
 					$requiredKubernetesVersionPresent = $true
 				}
+				elseif ($null -eq $this.ResourceObject.Properties.kubernetesVersion) {
+					$requiredKubernetesVersionPresent = $true
+				}
 			}
 
 			if(-not $requiredKubernetesVersionPresent)


### PR DESCRIPTION
## Description
</br>

The kubernetesVersion property (if not present or null) will deploy the latest version of AKS. This sets a pass of the control (to use the latest version) while keeping other checks in place.

## Checklist
- [x] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [x] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [x] The title of the PR clearly describes the intent of the PR.
- [x] This PR does not introduce any breaking changes to the code.
