### PR TITLE
[Do not merge] Added condition to print org-policy mismatch warning only once

### DIFF
--- a/src/AzSK.Framework/Helpers/Constants.ps1
+++ b/src/AzSK.Framework/Helpers/Constants.ps1
@@ -68,6 +68,8 @@ class Constants
     static [string] $CompletedAnalysis = [Constants]::SingleDashLine + "`r`nCompleted analysis: [FeatureName: {0}] [ResourceGroupName: {1}] [ResourceName: {2}] `r`n" + [Constants]::DoubleDashLine
     static [string] $CompletedAnalysisSub = [Constants]::SingleDashLine + "`r`nCompleted analysis: [FeatureName: {0}] [SubscriptionName: {1}] [SubscriptionId: {2}] `r`n" + [Constants]::DoubleDashLine
 	static [string] $PIMAPIUri="https://api.azrbac.mspim.azure.com/api/v2/privilegedAccess/azureResources/resources";
+	# Counter to check number of times org policy has been checked.
+	static [int] $ValidateOrgPolicyCount = 0
 	#Constants for Attestation
 	static [string] $AttestedControlsScanMsg = "You are almost done...we will perform a quick scan of controls attested within the last 24 hrs so that the backend will get the latest control status."
 	static [string] $ModuleAttestStartHeading = [Constants]::DoubleDashLine +

--- a/src/AzSK/Framework/Abstracts/AzCommandBase.ps1
+++ b/src/AzSK/Framework/Abstracts/AzCommandBase.ps1
@@ -18,7 +18,12 @@ class AzCommandBase: CommandBase {
 		[Helpers]::AbstractClass($this, [AzCommandBase]);
 
 		#Validate if command is getting run with correct Org Policy
-		$IsTagSettingRequired = $this.ValidateOrgPolicyOnSubscription($this.Force)
+		$IsTagSettingRequired = $false
+		if ([Constants]::ValidateOrgPolicyCount -eq 0)
+		{
+			[Constants]::ValidateOrgPolicyCount = [Constants]::ValidateOrgPolicyCount + 1;
+			$IsTagSettingRequired = $this.ValidateOrgPolicyOnSubscription($this.Force)
+		}
 		
 		#Validate if policy url token is getting expired 
 		$onlinePolicyStoreUrl = [ConfigurationManager]::GetAzSKSettings().OnlinePolicyStoreUrl


### PR DESCRIPTION
## Description

Added to a counter to skip org-policy validation warning second time in a row.

## Points to be discussed
1. The counter var that is being used to track the count of policy check is set as constant. As a result, the policy is checked only once per PS session. We should reset this counter at the end of AzSK cmdlet execution. Where in the module should this be added?

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
