### PR TITLE
Users/zhilmil/2002 updates

### DIFF
--- a/src/AzSK.Framework/Listeners/UserReports/WritePsConsole.ps1
+++ b/src/AzSK.Framework/Listeners/UserReports/WritePsConsole.ps1
@@ -581,10 +581,20 @@ class WritePsConsole: FileOutputBase
                 $ky = $item.Alias
                 $vl = $item.Value
 
-				if($vl -eq $true)
-                {
-                    $vl = ""
-                }
+				
+				if($vl.GetType().Name -in @('String','String[]'))
+				{
+					$vl = '"' + $vl + '"'
+				}
+				elseif($vl -in @($true, $false) -and $vl.GetType().Name -ne 'SwitchParameter' )
+				{
+					$vl = '$'+$vl.ToString().ToLower()
+				}
+				elseif($vl.GetType().Name -eq 'SwitchParameter')
+				{
+					$vl = ""
+				}
+				
                 if($ky)
                 {
                     $cmID += "-$ky $vl "

--- a/src/AzSK.Framework/Models/SubscriptionSecurity/SubscriptionRBAC.ps1
+++ b/src/AzSK.Framework/Models/SubscriptionSecurity/SubscriptionRBAC.ps1
@@ -38,6 +38,38 @@ class TelemetryRBAC
 	[string] $RoleDefinitionId="";
 	[string] $RoleDefinitionName="";
 	[bool] $IsPIMEnabled;
+
+
+	TelemetryRBAC()
+	{
+	}
+	TelemetryRBAC([TelemetryRBAC] $RoleAssignment)
+	{
+		$this.SubscriptionId = $RoleAssignment.SubscriptionId
+		$this.Scope = $RoleAssignment.Scope;
+		$this.DisplayName = $RoleAssignment.DisplayName;
+		$this.MemberType = $RoleAssignment.MemberType;
+		$this.ObjectId = $RoleAssignment.ObjectId;
+		$this.ObjectType = $RoleAssignment.ObjectType;
+		$this.RoleAssignmentId = $RoleAssignment.RoleAssignmentId
+		$this.RoleDefinitionId = $RoleAssignment.RoleDefinitionId
+		$this.RoleDefinitionName = $RoleAssignment.RoleDefinitionName
+		$this.IsPIMEnabled = $RoleAssignment.IsPIMEnabled;
+
+	}
+	
+}
+class TelemetryRBACExtended : TelemetryRBAC
+{
+	[string] $PrincipalName= [string]::Empty
+
+	TelemetryRBACExtended([TelemetryRBAC] $RoleAssignment,[string] $PrincipalName):
+	Base([TelemetryRBAC] $RoleAssignment)
+	{
+	
+		$this.PrincipalName = $PrincipalName
+
+	}
 	
 }
 enum RBACAccountType

--- a/src/AzSK/Framework/Core/PIM/PIMScript.ps1
+++ b/src/AzSK/Framework/Core/PIM/PIMScript.ps1
@@ -329,11 +329,11 @@ class PIM: AzCommandBase {
                 $roleAssignments = $roleAssignments | Where-Object { $_.MemberType -ne 'Inherited' -and ($_.SubjectType -eq 'User' -or $_.SubjectType -eq 'Group') }
             }
             if (($roleAssignments | Measure-Object).Count -gt 0) {
-                $roleAssignments = $roleAssignments | Sort-Object -Property RoleName, Name, AssignmentState
+                $roleAssignments = $roleAssignments | Sort-Object -Property RoleName, Name, AssignmentState, ResourceId
                 $this.PublishCustomMessage("")
                 $this.PublishCustomMessage("Note: The assignments listed below do not include 'inherited' assignments for the scope.", [MessageType]::Warning)
                 $this.PublishCustomMessage([Constants]::SingleDashLine, [MessageType]::Default)
-                $this.PublishCustomMessage($($roleAssignments | Format-Table -Property @{Label = "Role"; Expression = { $_.RoleName } }, PrincipalName, AssignmentState, @{Label = "Type"; Expression = { $_.SubjectType } } | Out-String), [MessageType]::Default)
+                $this.PublishCustomMessage($($roleAssignments | Format-Table -Property PrincipalName, @{Label = "Role"; Expression = { $_.RoleName } },  AssignmentState, @{Label = "Type"; Expression = { $_.SubjectType } } | Out-String), [MessageType]::Default)
             }
             else {
                 if ($CheckPermanent) {
@@ -604,8 +604,9 @@ class PIM: AzCommandBase {
     }
 
     # Below method is intended to assign equivalent PIM eligible roles for permanent assignments for a given role on a particular resource
-    hidden AssignPIMforPermanentAssignemnts($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $DurationInDays, $Force) 
+    hidden AssignPIMforPermanentAssignemnts($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $DurationInDays, $PrincipalNames, $Force) 
     {
+        $principalTransitioned = @();
         $resolvedResource = $this.PIMResourceResolver($subscriptionId, $resourcegroupName, $resourceName,$false)
         if (($resolvedResource | Measure-Object).Count -gt 0 -and (-not [string]::IsNullOrEmpty($resolvedResource.ResourceId))) {    
             $resourceId = $resolvedResource.ResourceId
@@ -614,8 +615,25 @@ class PIM: AzCommandBase {
             $CriticalRoles = $roles.RoleName 
             $this.PublishCustomMessage("Fetching permanent assignment for [$(($criticalRoles) -join ", ")] role on $($resolvedResource.Type) [$($resolvedResource.ResourceName)]...",[MessageType]::Info)
             $permanentRoles = $this.ListAssignmentsWithFilter($resourceId, $true)
+            $permanentRolesForTransition = @();
             if (($permanentRoles | Measure-Object).Count -gt 0) {
-                $permanentRolesForTransition = $permanentRoles | Where-Object { ($_.SubjectType -eq 'User' -or $_.SubjectType -eq 'Group'  )-and $_.MemberType -ne 'Inherited' -and $_.RoleName -in $CriticalRoles }
+                $permanentRoles = $permanentRoles | Where-Object { ($_.SubjectType -eq 'User' -or $_.SubjectType -eq 'Group'  )-and $_.MemberType -ne 'Inherited' -and $_.RoleName -in $CriticalRoles }
+                if(($PrincipalNames | Measure-Object).Count -gt 0) # checking if assignment only for certain UPNs are to be removed
+                {
+                    $principalNames = $principalNames.Split(',').Trim()
+                    $permanentRolesForTransition += $permanentRoles | Where-Object {$_.PrincipalName -in $principalNames}
+                    if( ($permanentRolesForTransition | Measure-Object).Count -eq 0)
+                    {
+                        $this.PublishCustomMessage("Unable to find matching permanent assignments for the principal names provided in `$PrincipalNames parameter.",[MessageType]::Warning)
+                        return;
+                    }
+                    
+                    
+                }
+                else
+                {
+                    $permanentRolesForTransition += $permanentRoles
+                }
                 if (($permanentRolesForTransition | Measure-Object).Count -gt 0) {
                     $ToContinue = ''
                     if(!$Force)
@@ -625,7 +643,8 @@ class PIM: AzCommandBase {
                         Write-Host "The above role assignments will be moved from 'permanent' to 'PIM'. `nPlease confirm (Y/N): " -ForegroundColor Yellow -NoNewline
                         $ToContinue = Read-Host
                     }
-                    if ($ToContinue -eq 'y' -or $Force) {               
+                    if ($ToContinue -eq 'y' -or $Force) 
+                    {               
                         $Assignmenturl = $this.APIroot + "/roleAssignmentRequests"
                         $roles = $this.ListRoles($resourceId)  
                         $ts = $DurationInDays;
@@ -644,6 +663,7 @@ class PIM: AzCommandBase {
                                 $response = Invoke-WebRequest -UseBasicParsing -Headers $this.headerParams -Uri $Assignmenturl -Method Post -ContentType "application/json" -Body $postParams
                                 if ($response.StatusCode -eq 201) {
                                     $this.PublishCustomMessage("[$i`/$totalPermanentAssignments] Successfully requested PIM assignment for [$PrincipalName]", [MessageType]::Update);
+                                    $principalTransitioned += $PrincipalName
                                 }
                                 $this.PublishCustomMessage([Constants]::SingleDashLine)
                           
@@ -653,6 +673,7 @@ class PIM: AzCommandBase {
                                     $err = $_ | ConvertFrom-Json
                                     if ($err.error.code -eq "RoleAssignmentExists") {
                                         $this.PublishCustomMessage("[$i`/$totalPermanentAssignments] PIM Assignment for [$PrincipalName] already exists.", [MessageType]::Warning)
+                                        $principalTransitioned += $PrincipalName
                                     }
                                     else {
                                         $this.PublishCustomMessage("[$i`/$totalPermanentAssignments] $($err.error.message)", [MessageType]::Error)
@@ -661,10 +682,23 @@ class PIM: AzCommandBase {
                             }         
                             $i++;
                         }#foreach  
+                        [string] $cmdmsg = ""
+                        $cmdmsg += "To remove the permanent assignments, please run `n setpim -RemovePermanentAssignments -SubscriptionId $SubscriptionId"
+                        if(-not [string]::IsNullOrEmpty($ResourceGroupName))
+                            { $cmdmsg += " -ResourceGroupName $ResourceGroupName "}
+                        if(-not [string]::IsNullOrEmpty($ResourceName))
+                            { $cmdmsg += " -ResourceName $ResourceName "}
+                        $cmdmsg += '-RoleNames "'+($Rolenames)+ '"'
+                        if(-not [string]::IsNullOrEmpty($PrincipalNames))
+                            {$cmdmsg += '-PrincipalNames "'+($principalTransitioned -join ', ')+ '"'}
+                            $this.PublishCustomMessage("")
+                        $this.PublishCustomMessage("This command will assign equivelant eligible role assignments for the above permanent assignments. $cmdmsg", [MessageType]::Warning)
+                        
                     }
                     else {
                         return;
                     }
+
                 }
                 else {
                     $this.PublishCustomMessage("No permanent assignments eligible for PIM assignment found.", [MessageType]::Warning);       
@@ -681,7 +715,7 @@ class PIM: AzCommandBase {
     }
 
     # Remove permanent assignments for a particular role on a given resource
-    hidden RemovePermanentAssignments($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $RemoveAssignmentFor, $Force) {
+    hidden RemovePermanentAssignments($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $RemoveAssignmentFor, $PrincipalNames, $Force) {
         $this.AcquireToken();
         $resolvedResource = $this.PIMResourceResolver($subscriptionId, $resourcegroupName, $resourceName,$false)
         if(-not [String]::IsNullOrEmpty($resolvedResource.ResourceId))
@@ -699,6 +733,17 @@ class PIM: AzCommandBase {
                 $successfullyassignedRoles = @();
                 $currentContext = [ContextHelper]::GetCurrentRmContext();
                 $permanentRolesForTransition = $permanentRolesForTransition | Where-Object { $_.PrincipalName -ne $currentContext.Account.Id }
+                if(($PrincipalNames |Measure-Object).Count -gt 0) # checking if assignment only for certain UPNs are to be removed
+                {
+                    $PrincipalNames = $PrincipalNames.Split(',').Trim()
+                    $permanentRolesForTransition =  $permanentRolesForTransition | Where-Object{$_.PrincipalName -in $PrincipalNames}
+                    if( ($permanentRolesForTransition | Measure-Object).Count -eq 0)
+                    {
+                        $this.PublishCustomMessage("Permanent assignments matching with principal names provided in `$PrincipalNames parameter are not found.",[MessageType]::Warning)
+                        return;
+                    }
+                }
+                
                 if ($RemoveAssignmentFor -ne "AllExceptMe") {
                     $eligibleAssignments | ForEach-Object {
                         $allUser = $_;
@@ -735,8 +780,8 @@ class PIM: AzCommandBase {
                         try
                         {
                             $i++;
-                            $this.PublishCustomMessage([Constants]::SingleDashLine);
-                            Remove-AzRoleAssignment -SignInName $user.PrincipalName -RoleDefinitionName $user.RoleName -Scope $user.OriginalId -ErrorAction Stop
+                            $this.PublishCustomMessage([Constants]::SingleDashLine);                            
+                            Remove-AzRoleAssignment -ObjectId $user.SubjectId -RoleDefinitionName $user.RoleName -Scope $user.OriginalId -ErrorAction Stop                             
                             $this.PublishCustomMessage("[$i`/$totalRemovableAssignments]Successfully removed permanent assignment", [MessageType]::Update )                
                             $this.PublishCustomMessage([Constants]::SingleDashLine);
                         }
@@ -770,6 +815,8 @@ class PIM: AzCommandBase {
             $this.PublishCustomMessage("No matching resource found for the current context.", [MessageType]::Warning)
         }
     }
+
+    
 
     # Get the assignments that are expiring in n days
     hidden  [PSObject] ListSoonToExpireAssignments($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $ExpiringInDays)

--- a/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
+++ b/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
@@ -1091,7 +1091,7 @@ class SubscriptionCore: AzSVTBase
 			if([FeatureFlightingManager]::GetFeatureStatus("FetchRGPIMControlStatusFromComplianceState",$($this.SubscriptionContext.SubscriptionId)) )
 			{
 				#[string] $controlId = $controlItem.ControlID;
-				$controlResult.AddMessage("Note: `n By default, this control is not evaluated in manual scan mode. The control status is based on the previous CA runbook scan for this control. To determine why this control has failed, you can look at the detailed log in the CA scan logs in the storage account in AzSKRG under a container named ca-scan-logs `n To force a manual scan, you can use the control id explicitly in the scan cmdlet (e.g., gss -s <sub_id> -cids 'Azure_Subscription_AuthZ_Dont_Grant_Persistent_Access_RG '")
+				$controlResult.AddMessage("Note: `n By default, this control is not evaluated in manual scan mode. The control status is based on the previous CA runbook scan for this control. To determine why this control has failed, you can look at the detailed log files in the storage account in AzSKRG under a container named 'ca-scan-logs' `n To force a manual scan, you can use the control id explicitly in the scan cmdlet (e.g., gss -s <sub_id> -cids 'Azure_Subscription_AuthZ_Dont_Grant_Persistent_Access_RG '")
 				$result = $this.GetControlStatusFromComplianceState('Azure_Subscription_AuthZ_Dont_Grant_Persistent_Access_RG');
 				# since this control has actually only two states 'Passed' and 'Failed', but in case we are not able to read attestation data we need to tell the reason for the same
 				

--- a/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
+++ b/src/AzSK/Framework/Core/SVT/SubscriptionCore/SubscriptionCore.ps1
@@ -19,6 +19,8 @@ class SubscriptionCore: AzSVTBase
 	hidden [System.Collections.Generic.List[TelemetryRBAC]] $permanentAssignments;
 	hidden [System.Collections.Generic.List[TelemetryRBAC]] $RGLevelPIMAssignments;
 	hidden [System.Collections.Generic.List[TelemetryRBAC]] $RGLevelPermanentAssignments;
+	hidden [System.Collections.Generic.List[TelemetryRBACExtended]] $PIMAssignmentswithPName = @();
+	hidden [System.Collections.Generic.List[TelemetryRBACExtended]] $PIMRGLevelAssignmentswithPName = @();
 	hidden [CustomData] $CustomObject;
 	hidden $SubscriptionExtId;
 
@@ -1517,8 +1519,6 @@ class SubscriptionCore: AzSVTBase
 
 	hidden [ControlResult] CheckNonAlternateAccountsinPIMAccess([ControlResult] $controlResult)
     {
-		if($this.HasGraphAPIAccess)
-		{
 			$AltAccountRegX = [string]::Empty;
 			$message = [string]::Empty;
 			if($null -eq $this.PIMAssignments)
@@ -1543,27 +1543,19 @@ class SubscriptionCore: AzSVTBase
 				$controlResult.AddMessage("Unable to get the alternate account pattern for your org. Please verify manually")
 				return $controlResult;
 			}
-			if(($this.PIMAssignments| Measure-Object).Count -gt 0)
+			if(($this.PIMAssignmentswithPName| Measure-Object).Count -gt 0)
 			{
 				# get pim assignments for critical roles at subscription level
-				$PIMAssignmentsForCriticalRoles = $this.PIMAssignments | Where-Object {$_.RoleDefinitionName -in $this.ControlSettings.CriticalPIMRoles.Subscription}
+				$PIMAssignmentsForCriticalRoles = $this.PIMAssignmentswithPName | Where-Object {$_.RoleDefinitionName -in $this.ControlSettings.CriticalPIMRoles.Subscription}
 				if(($PIMAssignmentsForCriticalRoles | Measure-Object).Count -gt 0)
 				{
-					$IdentityName= $PIMAssignmentsForCriticalRoles.DisplayName | Get-Unique
-					$Users = @();
-					# we currently do not have principal names stored in the PIMAssignments object thus need to get the principal name explicitly
-					$IdentityName | ForEach-Object{
-						
-						$Users += Get-AzADUser -DisplayName $_
-					}
-
-					
-					$nonAltPIMAccounts = $Users | Where-Object{$_.UserPrincipalName -notmatch $AltAccountRegX}
+										
+					$nonAltPIMAccounts = $PIMAssignmentsForCriticalRoles | Where-Object{$_.PrincipalName -notmatch $AltAccountRegX}
 					if(($nonAltPIMAccounts | Measure-Object).Count -gt 0)
 					{
 						$nonAltPIMAccountsWithRoles = $PIMAssignmentsForCriticalRoles | Where-Object{$_.DisplayName -in $nonAltPIMAccounts.DisplayName}
 						$controlResult.AddMessage([VerificationResult]::Failed, "Non alternate accounts are assigned critical roles")
-						$controlResult.AddMessage($nonAltPIMAccountsWithRoles)
+						$controlResult.AddMessage($($nonAltPIMAccountsWithRoles | Select-Object -Property "PrincipalName", "RoleDefinitionName","Scope","ObjectType" ))
 					}
 					else
 					{
@@ -1571,12 +1563,8 @@ class SubscriptionCore: AzSVTBase
 					}
 				}
 			}
-		}
-		else
-		{
-			$controlResult.CurrentSessionContext.Permissions.HasRequiredAccess = $false;
-			$controlResult.AddMessage([VerificationResult]::Manual, "Not able to query Graph API. Please verify manually.");
-		}
+		
+		
 
 	return $controlResult;
 	}
@@ -1750,7 +1738,8 @@ class SubscriptionCore: AzSVTBase
 										#If roleAssignment is non permanent, even the active PIM assignments would appear in this list
 										$item.IsPIMEnabled=$true;
 										$this.PIMAssignments.Add($item);
-										
+										$tempRBExtendObject = [TelemetryRBACExtended]::new($item, $roleAssignment.subject.principalName)
+										$this.PIMAssignmentswithPName.Add($tempRBExtendObject);
 									}
 									else
 									{
@@ -1834,6 +1823,8 @@ class SubscriptionCore: AzSVTBase
 										#If roleAssignment is non permanent and not active
 										$item.IsPIMEnabled=$true;
 										$this.RGLevelPIMAssignments.Add($item);
+										$tempRBExtendObject = [TelemetryRBACExtended]::new($item, $roleAssignment.subject.principalName)
+										$this.PIMRGLevelAssignmentswithPName.Add($tempRBExtendObject);
 										
 									}
 									else

--- a/src/AzSK/PIM/PIM.ps1
+++ b/src/AzSK/PIM/PIM.ps1
@@ -129,6 +129,8 @@ function Set-AzSKPIMConfiguration {
 
         [Parameter(Mandatory = $true, ParameterSetName = "Assign")]
         [Parameter(Mandatory = $true, ParameterSetName = "ExtendExpiringAssignmentForUsers")]
+        [Parameter(Mandatory = $false, ParameterSetName = "AssignEligibleforPermanentAssignments")]
+        [Parameter(Mandatory = $false, ParameterSetName = "RemovePermanentAssignment")]
         [ValidateNotNullOrEmpty()]
 	    [Alias("pn","PrincipalName","GroupName")]
         [string[]]
@@ -194,10 +196,10 @@ function Set-AzSKPIMConfiguration {
                 $pimconfig.InvokeFunction($pimconfig.AssignExtendPIMRoleForUser, @($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleName, $PrincipalNames, $DurationInDays, $false))
             }
             elseif ($PSCmdlet.ParameterSetName -eq 'AssignEligibleforPermanentAssignments') {
-                $pimconfig.InvokeFunction($pimconfig.AssignPIMforPermanentAssignemnts, @($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $DurationInDays, $Force))
+                $pimconfig.InvokeFunction($pimconfig.AssignPIMforPermanentAssignemnts, @($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $DurationInDays, $PrincipalNames, $Force))
             }	
             elseif ($PSCmdlet.ParameterSetName -eq 'RemovePermanentAssignment') {
-                $pimconfig.InvokeFunction($pimconfig.RemovePermanentAssignments, @($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $RemoveAssignmentFor, $Force))
+                $pimconfig.InvokeFunction($pimconfig.RemovePermanentAssignments, @($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $RemoveAssignmentFor, $PrincipalNames, $Force))
             }
             elseif ($PSCmdlet.ParameterSetName -eq 'ExtendExpiringAssignments') {
                 $pimconfig.InvokeFunction($pimconfig.ExtendSoonToExpireAssignments, @($SubscriptionId, $ResourceGroupName, $ResourceName, $RoleNames, $ExpiringInDays, $DurationInDays, $Force))


### PR DESCRIPTION
## Description
1) Bug fix for incorrect short command displayed on PS console
2) Changes to make 'Azure_Subscription_Use_Only_Alt_Credentials' control scan without graph read access
3) Added principalnames parameter in setpim -AssignEligibleForPermanentAssignments and -RemovePermanentAssignment command to ease end users in case they want to remove/assign only their app members for their app team

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
