### PR TITLE
Removed unnecessary properties for VM public ip control

### DIFF
--- a/src/AzSK/Framework/Configurations/SVT/Services/VirtualMachine.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/VirtualMachine.json
@@ -95,10 +95,7 @@
           ],
           "Enabled": true,
           "DataObjectProperties": [
-             "PublicIpAllocationMethod",
-             "IpConfiguration",
-             "Id",
-             "DnsSettings"
+             "Id"
           ]
        },
        {

--- a/src/AzSK/Framework/Configurations/SVT/Services/VirtualMachine.json
+++ b/src/AzSK/Framework/Configurations/SVT/Services/VirtualMachine.json
@@ -96,7 +96,11 @@
           "Enabled": true,
           "DataObjectProperties": [
              "Id"
-          ]
+          ],
+          "OnAttestationDrift": {
+            "ApplyToVersionsUpto": "4.10.0",
+            "ActionOnAttestationDrift": "RespectExistingAttestationExpiryPeriod"
+        }
        },
        {
           "ControlID": "Azure_VirtualMachine_DP_Enable_Disk_Encryption",


### PR DESCRIPTION
I have fixed issue for control "Azure_VirtualMachine_NetSec_Justify_PublicIPs"

There are some properties which are unnecessary added into the configuration file, so I have removed those properties and keeps only required properties.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
