### PR TITLE
Various perf and bug fixes (perf ~AzSK 4.12.x)

### DIFF
--- a/src/AzSK.AzureDevOps/Framework/Abstracts/ADOSVTBase.ps1
+++ b/src/AzSK.AzureDevOps/Framework/Abstracts/ADOSVTBase.ps1
@@ -29,25 +29,11 @@ class ADOSVTBase: SVTBase {
 				return $true
 			}
 		}
-
-		if (($null -ne $this.ControlSettings) -and [Helpers]::CheckMember($this.ControlSettings, "BaselineControls.SubscriptionControlIdList")) {
-			$baselineControl = $this.ControlSettings.BaselineControls.SubscriptionControlIdList | Where-Object { $_ -eq $controlId }
-			if (($baselineControl | Measure-Object).Count -gt 0 ) {
-				return $true
-			}
-		}
 		return $false
 	}
 	hidden [bool] CheckPreviewBaselineControl($controlId) {
 		if (($null -ne $this.ControlSettings) -and [Helpers]::CheckMember($this.ControlSettings, "PreviewBaselineControls.ResourceTypeControlIdMappingList")) {
 			$PreviewBaselineControls = $this.ControlSettings.PreviewBaselineControls.ResourceTypeControlIdMappingList | Where-Object { $_.ControlIds -contains $controlId }
-			if (($PreviewBaselineControls | Measure-Object).Count -gt 0 ) {
-				return $true
-			}
-		}
-
-		if (($null -ne $this.ControlSettings) -and [Helpers]::CheckMember($this.ControlSettings, "PreviewBaselineControls.SubscriptionControlIdList")) {
-			$PreviewBaselineControls = $this.ControlSettings.PreviewBaselineControls.SubscriptionControlIdList | Where-Object { $_ -eq $controlId }
 			if (($PreviewBaselineControls | Measure-Object).Count -gt 0 ) {
 				return $true
 			}

--- a/src/AzSK.AzureDevOps/Framework/Core/SVT/AzureDevOps/AzureDevOps.Build.ps1
+++ b/src/AzSK.AzureDevOps/Framework/Core/SVT/AzureDevOps/AzureDevOps.Build.ps1
@@ -4,15 +4,18 @@ class Build: ADOSVTBase
 
     hidden [PSObject] $BuildObj;
     hidden [string] $SecurityNamespaceId;
+    hidden static [PSObject] $SecurityNamespacesObj = $null;
     
     Build([string] $subscriptionId, [SVTResource] $svtResource): Base($subscriptionId,$svtResource) 
     {
         # Get security namespace identifier of current build.
         $apiURL = "https://dev.azure.com/{0}/_apis/securitynamespaces?api-version=5.0" -f $($this.SubscriptionContext.SubscriptionName)
-        $securityNamespacesObj = [WebRequestHelper]::InvokeGetWebRequest($apiURL);
-        $this.SecurityNamespaceId = ($securityNamespacesObj | Where-Object { ($_.Name -eq "Build") -and ($_.actions.name -contains "ViewBuilds")}).namespaceId
+        if ([Build]::SecurityNamespacesObj -eq $null)
+        {
+            [Build]::SecurityNamespacesObj = [WebRequestHelper]::InvokeGetWebRequest($apiURL);
+        }
+        $this.SecurityNamespaceId = ([Build]::SecurityNamespacesObj | Where-Object { ($_.Name -eq "Build") -and ($_.actions.name -contains "ViewBuilds")}).namespaceId
 
-        $securityNamespacesObj = $null;
         # Get build object
         $apiURL = $this.ResourceContext.ResourceId
         $this.BuildObj = [WebRequestHelper]::InvokeGetWebRequest($apiURL);

--- a/src/AzSK.AzureDevOps/Framework/Core/SVT/SVTResourceResolver.ps1
+++ b/src/AzSK.AzureDevOps/Framework/Core/SVT/SVTResourceResolver.ps1
@@ -117,14 +117,16 @@ class SVTResourceResolver: AzSKRoot {
 
         if ($this.ProjectNames -eq "*" -or $this.BuildNames -eq "*" -or $this.ReleaseNames -eq "*" -or $this.ServiceConnections -eq "*" -or $this.AgentPools -eq "*") {            
             $this.PublishCustomMessage("Using '*' can take a long time for the scan to complete in larger projects. `nYou may want to provide a comma-separated list of projects, builds, releases, service connections and agent pools. `n ", [MessageType]::Warning);
-            
+            <# BUGBUG: [Aug-2020] Removing this until we can determine the right approach to init org-policy-url for ADO.
             if (!$this.ControlSettings) {
                 $this.ControlSettings = [ConfigurationManager]::LoadServerConfigFile("ControlSettings.json");
             }
             #fetch control settings to check whether large scans are allowed in the org
             $this.isAllowLongRunningScanInPolicy = $this.ControlSettings.IsAllowLongRunningScan; 
-            $this.longRunningScanCheckPoint = $this.ControlSettings.LongRunningScanCheckPoint;       
-            }
+            $this.longRunningScanCheckPoint = $this.ControlSettings.LongRunningScanCheckPoint;     
+            #>
+  
+        }
     }
 
     [void] LoadResourcesForScan() {

--- a/src/AzSK.Framework/Abstracts/CommandBase.ps1
+++ b/src/AzSK.Framework/Abstracts/CommandBase.ps1
@@ -118,9 +118,9 @@ class CommandBase: AzSKRoot {
 		}
         else {
 
-		# Reset cached context <TODO Framework: Fix Dependancy on RM module>
-		[ContextHelper]::ResetCurrentContext()
 
+
+			
 		# Publish runidentifier(YYYYMMDD_HHMMSS) used by all listener as identifier for scan,creating log folder 
 		$this.PublishRunIdentifier($this.InvocationContext);
 		

--- a/src/AzSK.Framework/Helpers/ConfigOverride.ps1
+++ b/src/AzSK.Framework/Helpers/ConfigOverride.ps1
@@ -116,5 +116,6 @@ class ConfigOverride
 		[ConfigurationHelper]::LocalPolicyEnabled = $false
 		[ContextHelper]::currentContext = $null
 		[ConfigurationHelper]::PolicyCacheContent = @()
+		[ConfigurationHelper]::NotExtendedTypes = @{}
 	}
 }

--- a/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
+++ b/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
@@ -10,6 +10,7 @@ class ConfigurationHelper {
 	hidden static [bool] $LocalPolicyEnabled = $false
 	hidden static [string] $ConfigPath = [string]::Empty
 	hidden static [Policy[]] $PolicyCacheContent = @()
+	hidden static $NotExtendedTypes = @{} #Used to remember Types we have checked already as to whether they are extended (e.g., Build.ext.ps1) or not.
 	hidden static [PSObject] LoadOfflineConfigFile([string] $fileName) {
 		return [ConfigurationHelper]::LoadOfflineConfigFile($fileName, $true);
 	}
@@ -65,6 +66,23 @@ class ConfigurationHelper {
 			throw [System.ArgumentException] ("The argument 'policyFileName' is null");
 		} 
 
+		if ($onlineStoreUri -match "\{0\}.*\{1\}" -and $useOnlinePolicyStore -eq $true)
+		{
+			[EventBase]::PublishGenericCustomMessage(" Org Policy URL not set yet: $onlineStoreUri", [MessageType]::Warning);
+		}
+
+		#Check if policy is present in cache and fetch the same if present
+		$cachedPolicyContent = [ConfigurationHelper]::PolicyCacheContent | Where-Object { $_.Name -eq $policyFileName }
+		if ($cachedPolicyContent)
+		{
+			$fileContent = $cachedPolicyContent.Content
+			if ($fileContent)
+			{
+				return $fileContent                                  
+			}
+		}
+		
+
 		if ($useOnlinePolicyStore) {
 			
 			if ([string]::IsNullOrWhiteSpace($onlineStoreUri)) {
@@ -77,89 +95,70 @@ class ConfigurationHelper {
 			#First load offline OSS Content
 			$fileContent = [ConfigurationHelper]::LoadOfflineConfigFile($policyFileName)
 
-			#Check if policy present in server using metadata file
+			#Check if policy is listed as present in server config metadata file
 			if (-not [ConfigurationHelper]::OfflineMode -and [ConfigurationHelper]::IsPolicyPresentOnServer($policyFileName, $useOnlinePolicyStore, $onlineStoreUri, $enableAADAuthForOnlinePolicyStore)) {
-				#Check if online policy is present in configuration cache and fetch same
-				$cachedPolicyContent = [ConfigurationHelper]::PolicyCacheContent | Where-Object { $_.Name -eq $policyFileName }
-				#Write-Host -ForegroundColor Yellow "Trying cache for $policyFileName"
-				if ($cachedPolicyContent) {
-					$fileContent = $cachedPolicyContent.Content
-					#Write-Host -ForegroundColor Green "**FOUND** $policyFileName"
-				}
-
-				#If policy file content is not present in cache then load it from server
-				else {
-					#Write-Host -ForegroundColor Yellow "**NOT FOUND** $policyFileName"
-					try {
-						if ([String]::IsNullOrWhiteSpace([ConfigurationHelper]::ConfigVersion) -and -not [ConfigurationHelper]::LocalPolicyEnabled) {
+				#Write-Host -ForegroundColor Yellow "**NOT FOUND** $policyFileName"
+				try {
+					if ([String]::IsNullOrWhiteSpace([ConfigurationHelper]::ConfigVersion) -and -not [ConfigurationHelper]::LocalPolicyEnabled) {
+						try {
+							$Version = [System.Version] ($global:ExecutionContext.SessionState.Module.Version);
+							$serverFileContent = [ConfigurationHelper]::InvokeControlsAPI($onlineStoreUri, $Version, $policyFileName, $enableAADAuthForOnlinePolicyStore);
+							[ConfigurationHelper]::ConfigVersion = $Version;
+						}
+						catch {
 							try {
-								$Version = [System.Version] ($global:ExecutionContext.SessionState.Module.Version);
+								$Version = ([ConfigurationHelper]::LoadOfflineConfigFile("AzSK.json")).ConfigSchemaBaseVersion;
 								$serverFileContent = [ConfigurationHelper]::InvokeControlsAPI($onlineStoreUri, $Version, $policyFileName, $enableAADAuthForOnlinePolicyStore);
 								[ConfigurationHelper]::ConfigVersion = $Version;
 							}
 							catch {
-								try {
-									$Version = ([ConfigurationHelper]::LoadOfflineConfigFile("AzSK.json")).ConfigSchemaBaseVersion;
-									$serverFileContent = [ConfigurationHelper]::InvokeControlsAPI($onlineStoreUri, $Version, $policyFileName, $enableAADAuthForOnlinePolicyStore);
-									[ConfigurationHelper]::ConfigVersion = $Version;
+								if (Test-Path $onlineStoreUri) {	
+									[EventBase]::PublishGenericCustomMessage("Running Org-Policy from local policy store location: [$onlineStoreUri]", [MessageType]::Warning);
+									$serverFileContent = [ConfigurationHelper]::LoadOfflineConfigFile($policyFileName, $true, $onlineStoreUri)
+									[ConfigurationHelper]::LocalPolicyEnabled = $true
 								}
-								catch {
-									if (Test-Path $onlineStoreUri) {	
-										[EventBase]::PublishGenericCustomMessage("Running Org-Policy from local policy store location: [$onlineStoreUri]", [MessageType]::Warning);
-										$serverFileContent = [ConfigurationHelper]::LoadOfflineConfigFile($policyFileName, $true, $onlineStoreUri)
-										[ConfigurationHelper]::LocalPolicyEnabled = $true
-									}
-									else {
-										throw $_
-									}
+								else {
+									throw $_
 								}
 							}
 						}
-						elseif ([ConfigurationHelper]::LocalPolicyEnabled) {
-							$serverFileContent = [ConfigurationHelper]::LoadOfflineConfigFile($policyFileName, $true, $onlineStoreUri)
-						}
-						else {
-							$Version = [ConfigurationHelper]::ConfigVersion ;
-							$serverFileContent = [ConfigurationHelper]::InvokeControlsAPI($onlineStoreUri, $Version, $policyFileName, $enableAADAuthForOnlinePolicyStore);
-						}
-	
-						#Completely override offline config if Server Override flag is enabled
-						if ([ConfigurationHelper]::IsOverrideOfflineEnabled($policyFileName)) {
-							$fileContent = $serverFileContent
-						}
-						else {
-							$fileContent = [Helpers]::MergeObjects($fileContent, $serverFileContent)	
-						}
-
-						#Store policy file content into cache	
-						$policy = [Policy]@{
-							Name    = $policyFileName
-							Content = $fileContent
-						}
-						[ConfigurationHelper]::PolicyCacheContent += $policy
-						#Write-Host -ForegroundColor Green "**ADDING TO CACHE** $policyFileName"
 					}
-					catch {
-						[ConfigurationHelper]::OfflineMode = $true;
-	
-						if (-not [ConfigurationHelper]::IsIssueLogged) {
-							if ([Helpers]::CheckMember($_, "Exception.Response.StatusCode") -and $_.Exception.Response.StatusCode.ToString().ToLower() -eq "unauthorized") {
-								[EventBase]::PublishGenericCustomMessage(("Not able to fetch org-specific policy. The current Azure subscription is not linked to your org tenant."), [MessageType]::Warning);
-								[ConfigurationHelper]::IsIssueLogged = $true
-							}
-							elseif ($policyFileName -eq [Constants]::ServerConfigMetadataFileName) {
-								[EventBase]::PublishGenericCustomMessage(("Not able to fetch org-specific policy. Validate if org policy URL is correct."), [MessageType]::Warning);
-								[ConfigurationHelper]::IsIssueLogged = $true
-							}
-							else {
-								[EventBase]::PublishGenericCustomMessage(("Error while fetching the policy [$policyFileName] from online store. " + [Constants]::OfflineModeWarning), [MessageType]::Warning);
-								[EventBase]::PublishGenericException($_);
-								[ConfigurationHelper]::IsIssueLogged = $true
-							}
-						}            
-					}					
-				}
+					elseif ([ConfigurationHelper]::LocalPolicyEnabled) {
+						$serverFileContent = [ConfigurationHelper]::LoadOfflineConfigFile($policyFileName, $true, $onlineStoreUri)
+					}
+					else {
+						$Version = [ConfigurationHelper]::ConfigVersion ;
+						$serverFileContent = [ConfigurationHelper]::InvokeControlsAPI($onlineStoreUri, $Version, $policyFileName, $enableAADAuthForOnlinePolicyStore);
+					}
 
+					#Completely override offline config if Server Override flag is enabled
+					if ([ConfigurationHelper]::IsOverrideOfflineEnabled($policyFileName)) {
+						$fileContent = $serverFileContent
+					}
+					else {
+						$fileContent = [Helpers]::MergeObjects($fileContent, $serverFileContent)	
+					}
+					#Write-Host -ForegroundColor Green "**ADDING TO CACHE** $policyFileName"
+				}
+				catch {
+					[ConfigurationHelper]::OfflineMode = $true;
+
+					if (-not [ConfigurationHelper]::IsIssueLogged) {
+						if ([Helpers]::CheckMember($_, "Exception.Response.StatusCode") -and $_.Exception.Response.StatusCode.ToString().ToLower() -eq "unauthorized") {
+							[EventBase]::PublishGenericCustomMessage(("Not able to fetch org-specific policy. The current Azure subscription is not linked to your org tenant."), [MessageType]::Warning);
+							[ConfigurationHelper]::IsIssueLogged = $true
+						}
+						elseif ($policyFileName -eq [Constants]::ServerConfigMetadataFileName) {
+							[EventBase]::PublishGenericCustomMessage(("Not able to fetch org-specific policy. Validate if org policy URL is correct."), [MessageType]::Warning);
+							[ConfigurationHelper]::IsIssueLogged = $true
+						}
+						else {
+							[EventBase]::PublishGenericCustomMessage(("Error while fetching the policy [$policyFileName] from online store. " + [Constants]::OfflineModeWarning), [MessageType]::Warning);
+							[EventBase]::PublishGenericException($_);
+							[ConfigurationHelper]::IsIssueLogged = $true
+						}
+					}            
+				}					
 			}
 
 			if (-not $fileContent) {
@@ -176,6 +175,15 @@ class ConfigurationHelper {
 		if (-not $fileContent) {
 			throw "The specified file '$policyFileName' is empty"                                  
 		}
+
+		#Store policy file content into cache. 
+		#Note: This will happen only once per file (whether found on server or not). 
+		#In case of SVT config JSONs, we will overwrite this (only once) right after resolving baselines/dynamic parameters in control recos, etc. (in LoadSVTConfig)
+		$policy = [Policy]@{
+			Name    = $policyFileName
+			Content = $fileContent
+		}
+		[ConfigurationHelper]::PolicyCacheContent += $policy
 
 		return $fileContent;
 	}


### PR DESCRIPTION
## Description
</br>
1) Perf fixes (to sync w. AzSK 4.12.x). 
  - Org policy caching. 
  - Resolved SVTConfig overlay. 
  - CheckBaselineControls (removed subscriptionList as n/a for ADO).
  - Added NotExtendedType hash table for perf.

2) Type load bug from AzSK 
   - If the type 'Build' is extended...Build-Release-Build sequence would not apply BuildExt to 2nd build object.)

3) Turned off 'IsLargeScanAllowed' check (too early). Need to revisit later.

4) Removed NA feature flag from LA helper/event sender.

5) Cached security config in Build object.


## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
