### PR TITLE
DevTest support in UCA

### DIFF
--- a/src/AzSK.ADO/ContinuousAssurance/ContinuousAssurance.ps1
+++ b/src/AzSK.ADO/ContinuousAssurance/ContinuousAssurance.ps1
@@ -194,7 +194,14 @@ function Update-AzSKADOContinuousAssurance
 		[Parameter(Mandatory = $false, ParameterSetName = "Default", HelpMessage = "Use extended command to narrow down the scans.")]
 		[Alias("ex")]
 		[string]
-		$ExtendedCommand
+		$ExtendedCommand,
+
+		#Dev-Test support params below this
+		[string] $RsrcTimeStamp, 
+		[string] $ContainerImageName, 
+		[string] $ModuleEnv, 
+		[bool] $UseDevTestImage, 
+		[int] $TriggerNextScanInMin
     )
 	Begin
 	{
@@ -208,7 +215,9 @@ function Update-AzSKADOContinuousAssurance
 			$resolver = [Resolver]::new($OrganizationName)
 			$caAccount = [CAAutomation]::new($SubscriptionId, $OrganizationName, $PATToken, `
 											$ResourceGroupName, $LAWSId, $LAWSSharedKey, `
-											$ProjectNames, $ExtendedCommand, $PSCmdlet.MyInvocation);
+											$ProjectNames, $ExtendedCommand, `
+											$RsrcTimeStamp, $ContainerImageName, $ModuleEnv, $UseDevTestImage, $TriggerNextScanInMin, `
+											$PSCmdlet.MyInvocation);
             
 			return $caAccount.InvokeFunction($caAccount.UpdateAzSKADOContinuousAssurance);
 		}


### PR DESCRIPTION
## Description
</br>
Added support for the following to facilitate faster dev-test for UCA:

> [string] $RsrcTimeStamp 
> [string] $ContainerImageName, 
> [string] $ModuleEnv, 
> [bool] $UseDevTestImage, 
> [int] $TriggerNextScanInMin

e.g., one can now run stuff like:

> $rgName='mpadorg'
> $extCmd = '-ubc'
> $nextScanMin = 2
> $imgName = 'mprabhu11/adosecurityscan'
> $devTest = $true
> $timeStamp= '200830092449'
> uca -sub $s4 -rg $rgName -oz $orgName -pn $newProj -ex $extCmd -rsrctimestamp $timeStamp -triggerNextScanInMin $nextScanMin -ContainerImageName $imgName -UseDevTestImage $true

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
