### PR TITLE
Getting user from PAT. PAT regex. Etc.

### DIFF
--- a/src/AzSK.ADO/Framework/Abstracts/ADOSVTCommandBase.ps1
+++ b/src/AzSK.ADO/Framework/Abstracts/ADOSVTCommandBase.ps1
@@ -98,8 +98,10 @@ class ADOSVTCommandBase: SVTCommandBase {
 
     [void] InitializeControlState() {
       if (-not $this.ControlStateExt) {
-          Write-Host -ForegroundColor Yellow "Remove call to AzSKSettings::new"
-          $settings = [AzSKSettings]::new($this.SubscriptionContext, $this.InvocationContext);
+          #ADOTODO: Do we still need this? 
+          #ADOTODO: The InvocationContext will change for each cmdlet run in a session. 
+          #So what benefit is there from caching the first one with AzSKSettings? (Need to investigate)
+          [AzSKSettings]::InitContexts($this.SubscriptionContext, $this.InvocationContext);
           $this.ControlStateExt = [ControlStateExtension]::new($this.SubscriptionContext, $this.InvocationContext);
           $this.ControlStateExt.UniqueRunId = $this.AttestationUniqueRunId
           $this.ControlStateExt.Initialize($false);

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -247,7 +247,8 @@
         "(?# To match general passwords.)^(?=\\D*\\d)(?=[^a-z]*[a-z])(?=[^A-Z]*[A-Z])(?=(\\w*\\W|\\w*))[0-9\\Wa-zA-Z]{7,20}$",
         "(?# To match SQL/MySQL conn strings.)((P|p)assword|pwd)\\s*=\\s*\\w+;?",
         "(?# To match Azure storage keys.)^[A-Za-z0-9/+]{86}==$",
-        "(?# To match storage SAS.)([^?]*\\?sv=)[^&]+(&s[a-z]=[^&]+){4}"
+        "(?# To match storage SAS.)([^?]*\\?sv=)[^&]+(&s[a-z]=[^&]+){4}",
+        "(?# To match ADO PATs.)^[a-z2-7]{52}$"
       ]
     },
     {
@@ -256,7 +257,8 @@
         "(?# To match general passwords.)^(?=\\D*\\d)(?=[^a-z]*[a-z])(?=[^A-Z]*[A-Z])(?=(\\w*\\W|\\w*))[0-9\\Wa-zA-Z]{7,20}$",
         "(?# To match SQL/MySQL conn strings.)((P|p)assword|pwd)\\s*=\\s*\\w+;?",
         "(?# To match Azure storage keys.)^[A-Za-z0-9/+]{86}==$",
-        "(?# To match storage SAS.)([^?]*\\?sv=)[^&]+(&s[a-z]=[^&]+){4}"
+        "(?# To match storage SAS.)([^?]*\\?sv=)[^&]+(&s[a-z]=[^&]+){4}",
+        "(?# To match ADO PATs.)^[a-z2-7]{52}$"
       ]
     },
     {

--- a/src/AzSK.ADO/Framework/Helpers/ContextHelper.ps1
+++ b/src/AzSK.ADO/Framework/Helpers/ContextHelper.ps1
@@ -177,7 +177,8 @@ class ContextHelper {
                     };
         $responseObj = Invoke-RestMethod -Method Get -Uri $apiURL -Headers $headers -UseBasicParsing
 
-        #If the token is valid, we get: "descriptor"="Microsoft.IdentityModel.Claims.ClaimsIdentity;72f988bf-86f1-41af-91ab-2d7cd011db47\mprabhu@microsoft.com"
+        #If the token is valid, we get: "descriptor"="Microsoft.IdentityModel.Claims.ClaimsIdentity;72f988bf-86f1-41af-91ab-2d7cd011db47\xyz@microsoft.com"
+        #Note that even for guest users, we get the host tenant (and not their native tenantId). E.g., "descriptor...;72f...47\pqr@live.com"
         #If the token is invalid, we get a diff object: "descriptor":"System:PublicAccess;aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $authNUserInfo = @(($responseObj.authenticatedUser.descriptor -split ';') -split '\\')
     

--- a/src/AzSK.ADO/Framework/Helpers/ContextHelper.ps1
+++ b/src/AzSK.ADO/Framework/Helpers/ContextHelper.ps1
@@ -164,6 +164,29 @@ class ContextHelper {
         #$contextObj.AccessToken = $patToken
         #$contextObj.AccessToken =  ConvertTo-SecureString -String $context.AccessToken -asplaintext -Force
         [ContextHelper]::currentContext = $contextObj
+
+
+        $apiURL = "https://dev.azure.com/{0}/_apis/connectionData" -f [ContextHelper]::orgName
+        #Note: cannot use this WRH method below due to ordering constraints during load in Framework.ps1
+        #$header = [WebRequestHelper]::GetAuthHeaderFromUri($apiURL);
+        $user = ""
+        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user, $contextObj.AccessToken)))
+        $headers = @{
+                        "Authorization"= ("Basic " + $base64AuthInfo); 
+                        "Content-Type"="application/json"
+                    };
+        $responseObj = Invoke-RestMethod -Method Get -Uri $apiURL -Headers $headers -UseBasicParsing
+
+        #If the token is valid, we get: "descriptor"="Microsoft.IdentityModel.Claims.ClaimsIdentity;72f988bf-86f1-41af-91ab-2d7cd011db47\mprabhu@microsoft.com"
+        #If the token is invalid, we get a diff object: "descriptor":"System:PublicAccess;aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        $authNUserInfo = @(($responseObj.authenticatedUser.descriptor -split ';') -split '\\')
+    
+        #Check if the above split resulted in 3 elements (valid token case)
+        if ($authNUserInfo.Count -eq 3)
+        {
+            $contextObj.Tenant.Id = $authNUserInfo[1]
+            $contextObj.Account.Id = $authNUserInfo[2]
+        }
     }
 
     static [string] GetCurrentSessionUser() {

--- a/src/AzSK.ADO/Framework/Models/AzSKSettings.ps1
+++ b/src/AzSK.ADO/Framework/Models/AzSKSettings.ps1
@@ -180,11 +180,11 @@ class AzSKSettings {
 							$branch = $parsedSettings.BranchId;
 						}
 						$parsedSettings.OnlinePolicyStoreUrl = $parsedSettings.OnlinePolicyStoreUrl -f $orgName, $projectName, $repoName, $branch
-						Write-Host -ForegroundColor Green "Using policy from: [$orgName::$projectName::$repoName]"
+						Write-Host -ForegroundColor Green "Online policy URL set to: [$orgName::$projectName::$repoName]"
 					}
 					else 
 					{
-						Write-Host -ForegroundColor Yellow "Not using online policy. No project specified. (*TODO*: Use explicit policyProject param?)"
+						Write-Host -ForegroundColor Yellow "Not using online policy. No project specified. (*TODO*: Change after adding explicit policyProject param?)"
 					}
 				}
 				

--- a/src/AzSK.ADO/Framework/Models/AzSKSettings.ps1
+++ b/src/AzSK.ADO/Framework/Models/AzSKSettings.ps1
@@ -53,7 +53,7 @@ class AzSKSettings {
 
     AzSKSettings([SubscriptionContext] $subscriptionContext, [InvocationInfo] $invocationContext)
 	{
-		Write-Host -ForegroundColor Yellow "Investigate!"
+		#Write-Host -ForegroundColor Yellow "Investigate!"
 		[AzSKSettings]::SubscriptionContext = $subscriptionContext;
 		[AzSKSettings]::InvocationContext = $invocationContext;		
 	}

--- a/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
+++ b/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
@@ -91,7 +91,9 @@ class ConfigurationHelper {
 				throw [System.ArgumentException] ("The argument 'onlineStoreUri' is null");
 			} 
 			
-			if ($policyFileName -eq [Constants]::ServerConfigMetadataFileName -and $null -ne [ConfigurationHelper]::ServerConfigMetadata) {
+			#Remember if the file we are attempting is SCMD.json
+			$bFetchingSCMD = ($policyFileName -eq [Constants]::ServerConfigMetadataFileName)
+			if ($bFetchingSCMD -and $null -ne [ConfigurationHelper]::ServerConfigMetadata) {
 				return [ConfigurationHelper]::ServerConfigMetadata;
 			}
 			#First load offline OSS Content
@@ -150,7 +152,7 @@ class ConfigurationHelper {
 							[EventBase]::PublishGenericCustomMessage(("Not able to fetch org-specific policy. The current Azure subscription is not linked to your org tenant."), [MessageType]::Warning);
 							[ConfigurationHelper]::IsIssueLogged = $true
 						}
-						elseif ($policyFileName -eq [Constants]::ServerConfigMetadataFileName) {
+						elseif ($bFetchingSCMD ) {
 							[EventBase]::PublishGenericCustomMessage(("Not able to fetch org-specific policy. Validate if org policy URL is correct."), [MessageType]::Warning);
 							[ConfigurationHelper]::IsIssueLogged = $true
 						}
@@ -161,6 +163,15 @@ class ConfigurationHelper {
 						}
 					}            
 				}					
+			}
+
+			#If we were trying to fetch SCMD and the returned JSON does not have 'OnlinePolicyList' something is wrong!
+			#In ADO this happens if ADOScanner_Policy_<ProjName> repo does not exist.
+			#ADOTOD: Perhaps we should query for repo being present when the OnlinePolicyURL is formed (or first used)
+			if ($bFetchingSCMD -and -not [Helpers]::CheckMember($fileContent, "OnlinePolicyList"))
+			{
+				[EventBase]::PublishGenericCustomMessage(("Org policy URL may be incorrect or policy-repo does not exist!`r`nReverting to local policy."), [MessageType]::Warning);
+				$fileContent = [ConfigurationHelper]::LoadOfflineConfigFile($policyFileName)
 			}
 
 			if (-not $fileContent) {
@@ -289,8 +300,9 @@ class ConfigurationHelper {
 		$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user, $rmContext.AccessToken)))
 		try {
 			$FileName = $policyFileName;
+			$ResponseHeaders = $null
 			$uri = $global:ExecutionContext.InvokeCommand.ExpandString($onlineStoreUri)
-			$webRequestResult = Invoke-RestMethod -Uri $uri -Method Get -ContentType "application/json" -Headers @{Authorization = ("Basic {0}" -f $base64AuthInfo) }
+			$webRequestResult = Invoke-RestMethod -Uri $uri -Method Get -ContentType "application/json" -Headers @{Authorization = ("Basic {0}" -f $base64AuthInfo) } #-ResponseHeadersVariable 'ResponseHeaders'
 			return $webRequestResult;
 		}
 		catch {

--- a/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
+++ b/src/AzSK.Framework/Helpers/ConfigurationHelper.ps1
@@ -300,7 +300,7 @@ class ConfigurationHelper {
 		$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user, $rmContext.AccessToken)))
 		try {
 			$FileName = $policyFileName;
-			$ResponseHeaders = $null
+			#$ResponseHeaders = $null #The '-ResponseHeadersVariable' param is supported in PS core, we should enable after moving to PS core. Will allow us to check response content-type etc.
 			$uri = $global:ExecutionContext.InvokeCommand.ExpandString($onlineStoreUri)
 			$webRequestResult = Invoke-RestMethod -Uri $uri -Method Get -ContentType "application/json" -Headers @{Authorization = ("Basic {0}" -f $base64AuthInfo) } #-ResponseHeadersVariable 'ResponseHeaders'
 			return $webRequestResult;


### PR DESCRIPTION
## Description
</br>

  - Added support to determine actual user from PAT (during context initialization). This allows us to do attestation using PATToken.
  - Handling of situations when SCMD cannot be downloaded (incorrect org policy URL, policy-repo doesn't exist, no permission, etc.). We revert back to local policy gracefully.
  - Include ADO PATToken regex for creds-in-pipelines control

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
