### PR TITLE
Change to use shorter hashlen for attestation.

### DIFF
--- a/src/AzSK.ADO/Framework/Abstracts/ADOSVTBase.ps1
+++ b/src/AzSK.ADO/Framework/Abstracts/ADOSVTBase.ps1
@@ -429,12 +429,7 @@ class ADOSVTBase: SVTBase {
 		$this.PostEvaluationCompleted($resourceSecurityResult);
 	}
 
-	hidden [void] PostEvaluationCompleted([SVTEventContext[]] $ControlResults) {
-		# If ResourceType is Databricks, reverting security protocol 
-		if ([Helpers]::CheckMember($this.ResourceContext, "ResourceType") -and $this.ResourceContext.ResourceType -eq "Microsoft.Databricks/workspaces") {
-			[Net.ServicePointManager]::SecurityProtocol = $this.currentSecurityProtocol 
-		}
-		
+	hidden [void] PostEvaluationCompleted([SVTEventContext[]] $ControlResults) {		
 		$this.UpdateControlStates($ControlResults);
 
 		$BugLogParameterValue =$this.InvocationContext.BoundParameters["AutoBugLog"]

--- a/src/AzSK.ADO/Framework/Abstracts/ADOSVTCommandBase.ps1
+++ b/src/AzSK.ADO/Framework/Abstracts/ADOSVTCommandBase.ps1
@@ -26,22 +26,6 @@ class ADOSVTCommandBase: SVTCommandBase {
 
         #Force load of AzSK.json
         $cfg = [ConfigurationManager]::GetAzSKConfigData();
-        
-         #Create necessary resources to save compliance data in user's subscription
-         #<TODO Perf Issue - ComplianceReportHelper fetch RG/Storage. Then creates RG/Storage/table if not exists. Check permissions for write etc>
-        # if($this.IsLocalComplianceStoreEnabled)
-        # {
-        #   #if($null -eq $this.ComplianceReportHelper)
-        #   #{
-        #   #    #Reset cached compliance report helper instance for accessing first fetch
-        #   #    [ComplianceReportHelper]::Instance = $null
-        #   #    $this.ComplianceReportHelper = [ComplianceReportHelper]::GetInstance($this.SubscriptionContext, $this.GetCurrentModuleVersion());                  
-        #   #}
-        #    if(-not $this.ComplianceReportHelper.HaveRequiredPermissions())
-        #    {
-        #        $this.IsLocalComplianceStoreEnabled = $false;
-        #    }
-        # }
     }
     #EndRegion
 
@@ -58,28 +42,22 @@ class ADOSVTCommandBase: SVTCommandBase {
 
 	[void] PostCommandStartedAction()
 	{
-		#$isPolicyInitiativeEnabled = [FeatureFlightingManager]::GetFeatureStatus("EnableAzurePolicyBasedScan",$($this.SubscriptionContext.SubscriptionId))
-        #if($isPolicyInitiativeEnabled)
-        #{
-        #    $this.PostPolicyComplianceTelemetry()        
-        #}
+
 	}
     [void] PostPolicyComplianceTelemetry()
 	{
-	#	[CustomData] $customData = [CustomData]::new();
-	#	$customData.Name = "PolicyComplianceTelemetry";		
-	#	$customData.Value = $this.SubscriptionContext.SubscriptionId;
-	#	$this.PublishCustomData($customData);			
+			
     }
     
     [void] CommandErrorExt([System.Management.Automation.ErrorRecord] $exception) {
-        #$this.CheckAndEnableAzTelemetry()
+
     }
 
     [void] CommandCompletedExt([SVTEventContext[]] $arguments) {
-        #$this.CheckAndEnableAzTelemetry()
+
     }
 
+    #ADOCleanup - remove this ComplianceData stuff...leftover from AzSK.
     [ComplianceStateTableEntity[]] FetchComplianceStateData([string] $resourceId)
 	{
         [ComplianceStateTableEntity[]] $ComplianceStateData = @();

--- a/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
+++ b/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
@@ -15,6 +15,11 @@ class AutoBugLog {
         $this.ControlStateExt = $ControlStateExt               
     }  
 
+    static [string] ComputeHashX([string] $dataToHash)
+	{
+		return [Helpers]::ComputeHashShort($dataToHash, [Constants]::AutoBugLogTagLen)
+	}
+
     #main function where bug logging takes place 
     hidden [void] LogBugInADO([SVTEventContext[]] $ControlResults, [string] $BugLogParameterValue) {
         #check if user has permissions to log bug for the current resource
@@ -170,7 +175,7 @@ class AutoBugLog {
             }
             'User' {
                 #TODO: User controls dont have a project associated with them, can be rectified in future versions
-                Write-Host "`nAuto bug logging for user control failures is currently unavailable" -ForegroundColor Red
+                Write-Host "`nAuto bug logging for user control failures is currently not supported." -ForegroundColor Red
                 return $false
             }
         }
@@ -409,8 +414,7 @@ class AutoBugLog {
         $stringToHash = $stringToHash.Replace("{0}", $ResourceId)
         $stringToHash = $stringToHash.Replace("{1}", $ControlId)
         #return the bug tag
-        $hashedTag = [Helpers]::ComputeHash($stringToHash)
-        $hashedTag="ADOScanID: " + $hashedTag.Substring(0, 12)
+        $hashedTag="ADOScanID: " + [AutoBugLog]::ComputeHashX($stringToHash)
         return $hashedTag
     }
 

--- a/src/AzSK.ADO/Framework/BugLog/AutoCloseBugManager.ps1
+++ b/src/AzSK.ADO/Framework/BugLog/AutoCloseBugManager.ps1
@@ -167,8 +167,8 @@ class AutoCloseBugManager {
         $stringToHash = $stringToHash.Replace("{0}", $ResourceId)
         $stringToHash = $stringToHash.Replace("{1}", $ControlId)
         #return the bug tag
-        $hashedTag = [Helpers]::ComputeHash($stringToHash)
-        $hashedTag = "ADOScanID: " + $hashedTag.Substring(0, 12)
+
+        $hashedTag = "ADOScanID: " + [AutoBugLog]::ComputeHashX($stringToHash)
         return $hashedTag
     }
 

--- a/src/AzSK.ADO/Framework/Core/SVT/SVTControlAttestation.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/SVTControlAttestation.ps1
@@ -11,7 +11,7 @@ class SVTControlAttestation
 	[AttestationOptions] $attestOptions;
 	hidden [PSObject] $ControlSettings ; 
 	hidden [SubscriptionContext] $SubscriptionContext;
-    hidden [InvocationInfo] $InvocationContext;
+	hidden [InvocationInfo] $InvocationContext;
 
 	SVTControlAttestation([SVTEventContext[]] $ctrlResults, [AttestationOptions] $attestationOptions, [SubscriptionContext] $subscriptionContext, [InvocationInfo] $invocationContext)
 	{
@@ -496,7 +496,9 @@ class SVTControlAttestation
 						
 									$controlState.AttestationStatus = $controlResult.AttestationStatus
 									$controlState.EffectiveVerificationResult = $controlResult.VerificationResult
-									$controlState.HashId = [Helpers]::ComputeHash($resourceValueKey.ToLower());
+
+									#This seems to be unused...also, we should look into if 'tolower()' should be done in general for rsrcIds.
+									$controlState.HashId = [ControlStateExtension]::ComputeHashX($resourceValueKey.ToLower());
 									$controlState.ResourceId = $resourceValueKey;
 									if($this.bulkAttestMode)
 									{

--- a/src/AzSK.ADO/Framework/Core/SVT/SVTControlAttestation.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/SVTControlAttestation.ps1
@@ -497,7 +497,7 @@ class SVTControlAttestation
 									$controlState.AttestationStatus = $controlResult.AttestationStatus
 									$controlState.EffectiveVerificationResult = $controlResult.VerificationResult
 
-									#This seems to be unused...also, we should look into if 'tolower()' should be done in general for rsrcIds.
+									#ADOTodo: This seems to be unused...also, we should look into if 'tolower()' should be done in general for rsrcIds.
 									$controlState.HashId = [ControlStateExtension]::ComputeHashX($resourceValueKey.ToLower());
 									$controlState.ResourceId = $resourceValueKey;
 									if($this.bulkAttestMode)

--- a/src/AzSK.ADO/Framework/Helpers/Constants.ps1
+++ b/src/AzSK.ADO/Framework/Helpers/Constants.ps1
@@ -93,6 +93,11 @@ class Constants
 			[AttestationStatus]::StateConfirmed ="6";
 			
 	}
+	#This is the number of hex-chars used for attestation hash index entries (and file names).
+	static [int] $AttestationHashLen = 64;
+
+	#This is the length of tag for auto-logged bugs (used to search if a bug exists for a given (resourceId,controlId) pair)
+	static [int] $AutoBugLogTagLen = 12;
 
 	#Ext Storage
 	static [string] $StorageUri = "https://extmgmt.dev.azure.com/{0}/_apis/extensionmanagement/installedextensions/azsdktm/ADOSecurityScanner/Data/Scopes/Default/Current/Collections/{1}/Documents/{2}?api-version=5.1-preview.1" 

--- a/src/AzSK.ADO/Framework/Managers/ControlStateExtension.ps1
+++ b/src/AzSK.ADO/Framework/Managers/ControlStateExtension.ps1
@@ -455,7 +455,7 @@ class ControlStateExtension
 		    return $webRequestResult.Project
 		}
 		catch {
-			Write-Output -ForegroupColor Yellow "Could not get attestation-project-name from Extension storage!"
+			Write-Output -ForegroundColor Yellow "Could not get attestation-project-name from Extension storage!"
 			return $null;
 		}
 	}

--- a/src/AzSK.Framework/Models/RemoteReports/ComplianceStateModel.ps1
+++ b/src/AzSK.Framework/Models/RemoteReports/ComplianceStateModel.ps1
@@ -1,5 +1,6 @@
 Set-StrictMode -Version Latest
 
+#ADOCleanup: Remove this...not needed for ADOScanner.
 class ComplianceStateTableEntity
 {
 	#partition key = resourceid/subscriptionid

--- a/src/AzSK/Framework/Core/SVT/SVTControlAttestation.ps1
+++ b/src/AzSK/Framework/Core/SVT/SVTControlAttestation.ps1
@@ -26,6 +26,7 @@ class SVTControlAttestation
 		$this.ControlSettings=$ControlSettingsJson = [ConfigurationManager]::LoadServerConfigFile("ControlSettings.json");
 	}
 
+
 	[AttestationStatus] GetAttestationValue([string] $AttestationCode)
 	{
 		switch($AttestationCode.ToUpper())
@@ -460,7 +461,7 @@ class SVTControlAttestation
 						
 									$controlState.AttestationStatus = $controlResult.AttestationStatus
 									$controlState.EffectiveVerificationResult = $controlResult.VerificationResult
-									$controlState.HashId = [Helpers]::ComputeHash($resourceValueKey.ToLower());
+									$controlState.HashId = [ControlStateExtension]::ComputeHashX($resourceValueKey.ToLower());
 									$controlState.ResourceId = $resourceValueKey;
 									if($this.bulkAttestMode)
 									{


### PR DESCRIPTION
Change to use similar helper for bug log.

## Description
</br>
Changed attestation to use shorter (12-hex-char) hashes. 
Added helper function in auto-bug-log for the same. (It was computing full hash string and using first 12 chars from that.)
Other clean-up.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
