### PR TITLE
[ADO] changes related to org, build and users for sprint2010

### DIFF
--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.Build.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.Build.json
@@ -191,6 +191,23 @@
         "SI"
       ],
       "Enabled": true
-    }
+    },
+    {
+      "ControlID": "ADO_Build_SI_Set_Authorization_Scope_To_Current_Project",
+      "Description": "Do not include loosely permissioned variable groups in your pipeline.",
+      "Id": "Build210",
+      "ControlSeverity": "High",
+      "Automated": "Yes",
+      "MethodName": "CheckBuildAuthorizationScope",
+      "Rationale": "Having projectCollection as build job authorization scope gives access to collection of projects instead of required project.",
+      "Recommendation": "1. Navigate to the build pipeline. 2. Click on options. 3. Select 'Current Project' under the option 'Build job authorization scope'.",
+      "Tags": [
+        "SDL",
+        "TCP",
+        "Automated",
+        "SI"
+      ],
+      "Enabled": true
+    }  
   ]
 }

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.Build.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.Build.json
@@ -193,19 +193,19 @@
       "Enabled": true
     },
     {
-      "ControlID": "ADO_Build_SI_Set_Authorization_Scope_To_Current_Project",
-      "Description": "Do not include loosely permissioned variable groups in your pipeline.",
+      "ControlID": "ADO_Build_AuthZ_Limit_Pipeline_Access",
+      "Description": "Limit scope of access for build pipeline to the current project.",
       "Id": "Build210",
-      "ControlSeverity": "High",
+      "ControlSeverity": "Medium",
       "Automated": "Yes",
-      "MethodName": "CheckBuildAuthorizationScope",
-      "Rationale": "Having projectCollection as build job authorization scope gives access to collection of projects instead of required project.",
-      "Recommendation": "1. Navigate to the build pipeline. 2. Click on options. 3. Select 'Current Project' under the option 'Build job authorization scope'.",
+      "MethodName": "CheckBuildAuthZScope",
+      "Rationale": "If pipelines use project collection level tokens, a vulnerability in components used by one project can be leveraged by an attacker to attack all other projects. This is also in keeping with the principle of least privilege.",
+      "Recommendation": "1. Navigate to the build pipeline. 2. Click on Options. 3. Set 'Build job authorization scope' to 'Current Project'.",
       "Tags": [
         "SDL",
         "TCP",
         "Automated",
-        "SI"
+        "AuthZ"
       ],
       "Enabled": true
     }  

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -50,7 +50,8 @@
           "ADO_Build_DP_No_PlainText_Secrets_In_Definition",
           "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time",
           "ADO_Build_SI_Disable_Task_Group_Edit_Permission",
-          "ADO_Build_SI_Disable_Variable_Group_Edit_Permission"
+          "ADO_Build_SI_Disable_Variable_Group_Edit_Permission",
+          "ADO_Build_SI_Set_Authorization_Scope_To_Current_Project"
         ]
       },
       {

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -215,7 +215,7 @@
   "AlernateAccountRegularExpressionForOrg": "^SC-.*@.*microsoft.com$",
   "Organization": {
     "InActiveUserActivityLogsPeriodInDays": 90,
-    "TopInActiveUserCount": 500,
+    "TopInActiveUserCount": 100,
     "TrustedExtensionPublishers": [
       "Microsoft",
       "Microsoft DevLabs"

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -51,7 +51,7 @@
           "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time",
           "ADO_Build_SI_Disable_Task_Group_Edit_Permission",
           "ADO_Build_SI_Disable_Variable_Group_Edit_Permission",
-          "ADO_Build_SI_Set_Authorization_Scope_To_Current_Project"
+          "ADO_Build_AuthZ_Limit_Pipeline_Access"
         ]
       },
       {

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -600,22 +600,21 @@ class Build: ADOSVTBase
         return $controlResult
     }
 
-    hidden [ControlResult] CheckBuildAuthorizationScope([ControlResult] $controlResult)
+    hidden [ControlResult] CheckBuildAuthZScope([ControlResult] $controlResult)
     {
         if([Helpers]::CheckMember($this.BuildObj[0],"jobAuthorizationScope"))
         {
             $jobAuthorizationScope = $this.BuildObj[0].jobAuthorizationScope
             if ($jobAuthorizationScope -eq "projectCollection") {
-                $controlResult.AddMessage([VerificationResult]::Failed,"projectCollection is selected as  build job authorization scope for the build : ", $this.BuildObj[0].name);
-                $controlResult.SetStateData("projectCollection is selected as  build job authorization scope for the build: ", $this.BuildObj[0].name);                 
+                $controlResult.AddMessage([VerificationResult]::Failed,"Access token of build pipeline is scoped to project collection.");               
             }
             else {
-                $controlResult.AddMessage([VerificationResult]::Passed,"currentProject is selected as  build job authorization scope for the current build.");                    
+                $controlResult.AddMessage([VerificationResult]::Passed,"Access token of build pipeline is scoped to current project.");                    
             }
         }
         else 
         {
-            $controlResult.AddMessage([VerificationResult]::Passed,"No Authorization scope found in build definition.");
+            $controlResult.AddMessage([VerificationResult]::Error,"Could not fetch pipeline authorization details.");
         }
         return $controlResult
     }

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -599,4 +599,24 @@ class Build: ADOSVTBase
 
         return $controlResult
     }
+
+    hidden [ControlResult] CheckBuildAuthorizationScope([ControlResult] $controlResult)
+    {
+        if([Helpers]::CheckMember($this.BuildObj[0],"jobAuthorizationScope"))
+        {
+            $jobAuthorizationScope = $this.BuildObj[0].jobAuthorizationScope
+            if ($jobAuthorizationScope -eq "projectCollection") {
+                $controlResult.AddMessage([VerificationResult]::Failed,"projectCollection is selected as  build job authorization scope for the build : ", $this.BuildObj[0].name);
+                $controlResult.SetStateData("projectCollection is selected as  build job authorization scope for the build: ", $this.BuildObj[0].name);                 
+            }
+            else {
+                $controlResult.AddMessage([VerificationResult]::Passed,"currentProject is selected as  build job authorization scope for the current build.");                    
+            }
+        }
+        else 
+        {
+            $controlResult.AddMessage([VerificationResult]::Passed,"No Authorization scope found in build definition.");
+        }
+        return $controlResult
+    }
 }

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Organization.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Organization.ps1
@@ -579,7 +579,7 @@ class Organization: ADOSVTBase
             }
             if(($inactiveUsers | Measure-Object).Count -gt 0)
             {
-                if($inactiveUsers.Count -gt $topInActiveUsers)
+                if($inactiveUsers.Count -ge $topInActiveUsers)
                 {
                     $controlResult.AddMessage("Displaying top $($topInActiveUsers) inactive users")
                 }
@@ -596,17 +596,17 @@ class Organization: ADOSVTBase
                 $neverActiveUsers = $inactiveUsers | Where-Object {$_.InactiveFromDays -eq "User was never active."}
                 $inactiveUsersWithDays = $inactiveUsers | Where-Object {$_.InactiveFromDays -ne "User was never active."} 
 
+                $neverActiveUsersCount = ($neverActiveUsers | Measure-Object).Count
+                if ($neverActiveUsersCount -gt 0) {
+                    $controlResult.AddMessage("`nTotal number of users who were never active: $($neverActiveUsersCount)");
+                    $controlResult.AddMessage("Review users present in the organization who were never active: ",$neverActiveUsers);
+                } 
+                
                 $inactiveUsersWithDaysCount = ($inactiveUsersWithDays | Measure-Object).Count
                 if($inactiveUsersWithDaysCount -gt 0) {
                     $controlResult.AddMessage("`nTotal number of users who are inactive from last $($this.ControlSettings.Organization.InActiveUserActivityLogsPeriodInDays) days: $($inactiveUsersWithDaysCount)");                
                     $controlResult.AddMessage("Review users present in the organization who are inactive from last $($this.ControlSettings.Organization.InActiveUserActivityLogsPeriodInDays) days: ",$inactiveUsersWithDays);
                 }
-
-                $neverActiveUsersCount = ($neverActiveUsers | Measure-Object).Count
-                if ($neverActiveUsersCount -gt 0) {
-                    $controlResult.AddMessage("`nTotal number of users who were never active: $($neverActiveUsersCount)");
-                    $controlResult.AddMessage("Review users present in the organization who were never active: ",$neverActiveUsers);
-                }            
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Passed,

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Organization.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Organization.ps1
@@ -102,6 +102,7 @@ class Organization: ADOSVTBase
                         $responsePrCollData = $responsePrCollData | Select-Object displayName,mailAddress,subjectKind
                         $stateData = @();
                         $stateData += $responsePrCollData
+                        $controlResult.AddMessage("Total number of Project Collection Service Accounts members: $($responsePrCollData.Count)"); 
                         $controlResult.AddMessage([VerificationResult]::Verify, "Review the members of the group Project Collection Service Accounts: ", $stateData); 
                         $controlResult.SetStateData("Members of the Project Collection Service Accounts group: ", $stateData); 
                     }

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Organization.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Organization.ps1
@@ -549,12 +549,22 @@ class Organization: ADOSVTBase
                 }
                 #inactive user with days from how many days user is inactive, if user account created and was never active, in this case lastaccessdate is default 01-01-0001
                 $inactiveUsersWithDays = ($inactiveUsers | Select-Object -Property @{Name="Name"; Expression = {$_.User.displayName}},@{Name="mailAddress"; Expression = {$_.User.mailAddress}},@{Name="InactiveFromDays"; Expression = { if (((Get-Date) -[datetime]::Parse($_.lastAccessedDate)).Days -gt 10000){return "User was never active."} else {return ((Get-Date) -[datetime]::Parse($_.lastAccessedDate)).Days} }})
-            
+                # segregate never active users from the list
+                $neverActiveUsers = $inactiveUsersWithDays | Where-Object {$_.InactiveFromDays -eq "User was never active."}
+
+                $inactiveUsersWithDays = $inactiveUsersWithDays | Where-Object {$_.InactiveFromDays -ne "User was never active."}
                 #set data for attestation
                 $inactiveUsers = ($inactiveUsers | Select-Object -Property @{Name="Name"; Expression = {$_.User.displayName}},@{Name="mailAddress"; Expression = {$_.User.mailAddress}})
                 
+                $controlResult.AddMessage("Total number of inactive review users present in the organization: $($inactiveUsers.Count)");
+
+                $controlResult.AddMessage("Total number of review users who are inactive from last $($this.ControlSettings.Organization.InActiveUserActivityLogsPeriodInDays) days: $($inactiveUsersWithDays.Count)");                
                 $controlResult.AddMessage([VerificationResult]::Failed,
                                         "Review users present in the organization who are inactive from last $($this.ControlSettings.Organization.InActiveUserActivityLogsPeriodInDays) days: ",$inactiveUsersWithDays);
+                if ($neverActiveUsers.Count) {
+                    $controlResult.AddMessage("Total number of review users who are never active: $($neverActiveUsers.Count)");
+                    $controlResult.AddMessage("Review users present in the organization who are never active ",$neverActiveUsers);
+                }            
                 $controlResult.SetStateData("Inactive users list: ", $inactiveUsers);
             }
             else {

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.User.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.User.ps1
@@ -12,25 +12,28 @@ class User: ADOSVTBase {
         try {
             if ($responseObj.Count -gt 0) {
                 $AccessPATList = $responseObj | Where-Object { $_.validto -gt $(Get-Date -Format "yyyy-MM-dd") }
-                if ($AccessPATList.Count -gt 0) {
-                    $controlResult.AddMessage("Total number of active user PATs: $($AccessPATList.Count)");
+                $AccessPATListCount = ($AccessPATList | Measure-Object).Count
+                if ($AccessPATListCount -gt 0) {
+                    $controlResult.AddMessage("Total number of active user PATs: $($AccessPATListCount)");
                     $fullAccessPATList = $AccessPATList | Where-Object { $_.scope -eq "app_token" }
                     $statusSet = $false # Use this variable to check whether scanStaus is already set
-                    if (($fullAccessPATList | Measure-Object).Count -gt 0) {
-                        $fullAccessPATListCount = ($fullAccessPATList | Measure-Object).Count
-                        $controlResult.AddMessage("Total number of PAT's configured with full access: $fullAccessPATListCount");
+
+                    $fullAccessPATListCount = ($fullAccessPATList | Measure-Object).Count 
+                    if ($fullAccessPATListCount -gt 0) {
+                        $controlResult.AddMessage("`nTotal number of PAT's configured with full access: $($fullAccessPATListCount)");
                         $fullAccessPATNames = $fullAccessPATList | Select displayName, scope 
                         $controlResult.AddMessage([VerificationResult]::Failed,
                             "The following PATs have been configured with full access: ", $fullAccessPATNames);
                         $statusSet = $true
                     }
+
                     $remainingPATList = $AccessPATList | Where-Object { $_.scope -ne "app_token" }
-                    if (($remainingPATList | Measure-Object).Count -gt 0){
-                        $remainingPATListCount = ($remainingPATList | Measure-Object).Count
-                        $controlResult.AddMessage("Total number of PATs configured with custom defined access: $remainingPATListCount");
+                    $remainingPATListCount = ($remainingPATList | Measure-Object).Count
+                    if ($remainingPATListCount -gt 0){
+                        $controlResult.AddMessage("`nTotal number of PATs configured with custom defined access: $remainingPATListCount");
                         $remainingAccessPATNames = $remainingPATList | Select displayName, scope 
                         if ($statusSet) {
-                            $controlResult.AddMessage("Verify that the following PATs have minimum required permissions: ", $remainingAccessPATNames)
+                            $controlResult.AddMessage("The following PATs have been configured with custom defined access: ", $remainingAccessPATNames)
                         }   
                         else {
                             $controlResult.AddMessage([VerificationResult]::Verify, "Verify that the following PATs have minimum required permissions: ", $remainingAccessPATNames)                        

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.User.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.User.ps1
@@ -15,9 +15,9 @@ class User: ADOSVTBase {
                 $AccessPATListCount = ($AccessPATList | Measure-Object).Count
                 if ($AccessPATListCount -gt 0) {
                     $controlResult.AddMessage("Total number of active user PATs: $($AccessPATListCount)");
-                    $fullAccessPATList = $AccessPATList | Where-Object { $_.scope -eq "app_token" }
                     $statusSet = $false # Use this variable to check whether scanStaus is already set
 
+                    $fullAccessPATList = $AccessPATList | Where-Object { $_.scope -eq "app_token" }
                     $fullAccessPATListCount = ($fullAccessPATList | Measure-Object).Count 
                     if ($fullAccessPATListCount -gt 0) {
                         $controlResult.AddMessage("`nTotal number of PAT's configured with full access: $($fullAccessPATListCount)");

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.User.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.User.ps1
@@ -20,8 +20,8 @@ class User: ADOSVTBase {
                     $fullAccessPATList = $AccessPATList | Where-Object { $_.scope -eq "app_token" }
                     $fullAccessPATListCount = ($fullAccessPATList | Measure-Object).Count 
                     if ($fullAccessPATListCount -gt 0) {
-                        $controlResult.AddMessage("`nTotal number of PAT's configured with full access: $($fullAccessPATListCount)");
-                        $fullAccessPATNames = $fullAccessPATList | Select displayName, scope 
+                        $controlResult.AddMessage("`nTotal number of PATs configured with full access: $($fullAccessPATListCount)");
+                        $fullAccessPATNames = $fullAccessPATList | Select-Object displayName, scope 
                         $controlResult.AddMessage([VerificationResult]::Failed,
                             "The following PATs have been configured with full access: ", $fullAccessPATNames);
                         $statusSet = $true
@@ -31,7 +31,7 @@ class User: ADOSVTBase {
                     $remainingPATListCount = ($remainingPATList | Measure-Object).Count
                     if ($remainingPATListCount -gt 0){
                         $controlResult.AddMessage("`nTotal number of PATs configured with custom defined access: $remainingPATListCount");
-                        $remainingAccessPATNames = $remainingPATList | Select displayName, scope 
+                        $remainingAccessPATNames = $remainingPATList | Select-Object displayName, scope 
                         if ($statusSet) {
                             $controlResult.AddMessage("The following PATs have been configured with custom defined access: ", $remainingAccessPATNames)
                         }   
@@ -151,13 +151,13 @@ class User: ADOSVTBase {
                         $controlResult.AddMessage("The following PATs expire after 30 days: ", $PATOList )
                     }
                     if (($PATExpri7Days | Measure-Object).Count -gt 0) {
-                        $controlResult.AddMessage([VerificationResult]::Failed, "Failed: Total number of PATs expire within 7 days: " +($PATExpri7Days | Measure-Object).Count )
+                        $controlResult.VerificationResult = [VerificationResult]::Failed
                     }
                     elseif (($PATExpri30Days | Measure-Object).Count -gt 0) {
-                        $controlResult.AddMessage([VerificationResult]::Verify, "Verify: Total number of PATs expire after 7 days but within 30 days: " +($PATExpri30Days | Measure-Object).Count )
+                        $controlResult.VerificationResult = [VerificationResult]::Verify
                     }
                     else {
-                        $controlResult.AddMessage([VerificationResult]::Passed, "Passed: No PATs have been found which expire within 30 days")
+                        $controlResult.AddMessage([VerificationResult]::Passed, "No PATs have been found which expire within 30 days.")
                     }
                 }
                 else {


### PR DESCRIPTION
## Description
</br>
Items addressed
1) Removed unnecessary log like "Failed/Verify" from ADO_User_AuthZ_Review_Token_Expiration
2) Segregated full access and others for ADO_User_AuthZ_PAT_Min_Access
3) Split display of "never" active v. not-active-for-N-days for ADO_Organization_AuthZ_Review_Inactive_Users
4) Added control at build/release level to limit AuthZ scope (=> attest if you need to still use x-project scope)

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
