### PR TITLE
[ADO] admin control updates plus edit task grp control for yaml pipelines plus gadi policy project

### DIFF
--- a/src/AzSK.ADO/AzSKADOInfo/AzSKADOInfo.ps1
+++ b/src/AzSK.ADO/AzSKADOInfo/AzSKADOInfo.ps1
@@ -72,7 +72,13 @@ function Get-AzSKADOInfo
 		[switch]
 		[Parameter(Mandatory = $false, HelpMessage = "Switch to specify whether to open output folder.")]
 		[Alias("dnof")]
-		$DoNotOpenOutputFolder
+		$DoNotOpenOutputFolder,
+
+		[string]
+		[Parameter(Mandatory = $false, HelpMessage="Name of the project hosting organization policy with which the scan should run.")]
+		[ValidateNotNullOrEmpty()]
+		[Alias("pp")]
+		$PolicyProject
     )
 	Begin
 	{

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -428,7 +428,7 @@ class Build: ADOSVTBase
     {
         #Task groups have type 'metaTask' whereas individual tasks have type 'task'
         $taskGroups = @();
-        if([Helpers]::CheckMember($this.BuildObj[0].process,"phases"))
+        if([Helpers]::CheckMember($this.BuildObj[0].process,"phases")) #phases is not available for YAML-based pipelines.
         {
             if([Helpers]::CheckMember($this.BuildObj[0].process.phases[0],"steps"))
             {
@@ -544,7 +544,14 @@ class Build: ADOSVTBase
         }
         else 
         {
-            $controlResult.AddMessage([VerificationResult]::Error,"Could not fetch the list of task groups used in the pipeline.");
+            if([Helpers]::CheckMember($this.BuildObj[0].process,"yamlFilename")) #if the pipeline is YAML-based - control should pass as task groups are not supported for YAML pipelines.
+            {
+                $controlResult.AddMessage([VerificationResult]::Passed,"Task groups are not supported in YAML pipelines.");
+            }   
+            else 
+            {
+                $controlResult.AddMessage([VerificationResult]::Error,"Could not fetch the list of task groups used in the pipeline.");    
+            }
         }
         return $controlResult;
     }

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Project.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Project.ps1
@@ -405,13 +405,13 @@ class Project: ADOSVTBase
                                 # Add the members of current group to this temp variable.
                                 $groupMembers += [AdministratorHelper]::AllPAMembers
                                 # Create a custom object to append members of current group with the group name. Each of these custom object is added to the global variable $allAdminMembers for further analysis of SC-Alt detection.
-                                $groupMembers | ForEach-Object {$allAdminMembers += @( [PSCustomObject] @{ name = $_.displayName; mailAddress = $_.mailAddress; groupName = $adminGroups[$i].displayName } )} 
+                                $groupMembers | ForEach-Object {$allAdminMembers += @( [PSCustomObject] @{ name = $_.displayName; mailAddress = $_.mailAddress; id = $_.identityId; groupName = $adminGroups[$i].displayName } )} 
                             }
                             
                             # clearing cached value in [AdministratorHelper]::AllPAMembers as it can be used in attestation later and might have incorrect group loaded.
                             [AdministratorHelper]::AllPAMembers = @();
                             # Filtering out distinct entries. A user might be added directly to the admin group or might be a member of a child group of the admin group.
-                            $allAdminMembers = $allAdminMembers| Sort-Object -Property mailAddress -Unique
+                            $allAdminMembers = $allAdminMembers| Sort-Object -Property id -Unique
 
                             if(($allAdminMembers | Measure-Object).Count -gt 0)
                             {
@@ -422,26 +422,32 @@ class Project: ADOSVTBase
                                     {
                                         $nonSCMembers = @();
                                         $nonSCMembers += $allAdminMembers | Where-Object { $_.mailAddress -notmatch $matchToSCAlt }
+                                        $nonSCCount = ($nonSCMembers | Measure-Object).Count
+
                                         $SCMembers = @();
                                         $SCMembers += $allAdminMembers | Where-Object { $_.mailAddress -match $matchToSCAlt }   
-                                        if (($nonSCMembers | Measure-Object).Count -gt 0) 
+                                        $SCCount = ($SCMembers | Measure-Object).Count
+
+                                        if ($nonSCCount -gt 0) 
                                         {
                                             $nonSCMembers = $nonSCMembers | Select-Object name,mailAddress,groupName
                                             $stateData = @();
                                             $stateData += $nonSCMembers
-                                            $controlResult.AddMessage([VerificationResult]::Verify, "Review the users having admin privileges with non SC-ALT accounts: ", $stateData); 
-                                            $controlResult.SetStateData("List of users having admin privileges with non SC-ALT accounts: ", $stateData); 
+                                            $controlResult.AddMessage([VerificationResult]::Failed, "`nTotal number of non SC-ALT accounts with admin privileges: $nonSCCount"); 
+                                            $controlResult.AddMessage("Review the non SC-ALT accounts with admin privileges: ", $stateData);  
+                                            $controlResult.SetStateData("List of non SC-ALT accounts with admin privileges: ", $stateData); 
                                         }
                                         else 
                                         {
                                             $controlResult.AddMessage([VerificationResult]::Passed, "No users have admin privileges with non SC-ALT accounts.");
                                         }
-                                        if (($SCMembers | Measure-Object).Count -gt 0) 
+                                        if ($SCCount -gt 0) 
                                         {
                                             $SCMembers = $SCMembers | Select-Object name,mailAddress,groupName
                                             $SCData = @();
                                             $SCData += $SCMembers
-                                            $controlResult.AddMessage("Users having admin privileges with SC-ALT accounts: ", $SCData);
+                                            $controlResult.AddMessage("`nTotal number of SC-ALT accounts with admin privileges: $SCCount");  
+                                            $controlResult.AddMessage("SC-ALT accounts with admin privileges: ", $SCData);  
                                         }
                                     }
                                     else {

--- a/src/AzSK.ADO/Framework/Core/SVT/SVTResourceResolver.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/SVTResourceResolver.ps1
@@ -365,7 +365,7 @@ class SVTResourceResolver: AzSKRoot {
                                 $Connections = $serviceEndpointObj | Where-Object { ($_.type -eq "azurerm" -or $_.type -eq "azure" -or $_.type -eq "git" -or $_.type -eq "github" -or $_.type -eq "externaltfs") -and ($this.ServiceConnections -eq $_.name) }  
                             }
 
-                            #Initialysing null to SecurityNamespaceId variable for new scan, it is static variable, setting once only in svc class and same value is applicable for all the svc con withing org
+                            #Initialising null to SecurityNamespaceId variable for new scan, it is static variable, setting once only in svc class and same value is applicable for all the svc con withing org
                             [ServiceConnection]::SecurityNamespaceId = $null;
                             $serviceEndpointObj = $null;
                             Remove-Variable  serviceEndpointObj;


### PR DESCRIPTION
## Description
</br>

 1. ADO_Organization_AuthN_Use_ALT_Accounts_For_Admin - control will now fail if atleast one non SC-ALT account is found. Printing count for both alt and non-alt entities. Also, skipping PCSA from alt account check
 
2. ADO_Project_AuthN_Use_ALT_Accounts_For_Admin - control will now fail if atleast one non SC-ALT account is found. Printing count for both alt and non-alt entities. 

3. ADO_Organization_SI_Review_Installed_Extensions - aded counted for trusted vs non-trusted extensions and also the criteria for trusting a publisher.

4. GADI will now work with org-policy based control info if PolicyProject flag is used.

5. ADO_Build_SI_Disable_Task_Group_Edit_Permission control will not error out for YAML pipelines.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
